### PR TITLE
Add guidance page and new start flow to unaccompanied minor

### DIFF
--- a/app/controllers/unaccompanied_controller.rb
+++ b/app/controllers/unaccompanied_controller.rb
@@ -4,6 +4,10 @@ class UnaccompaniedController < ApplicationController
   include ApplicationHelper
   MAX_STEPS = 12
 
+  def guidance
+    render "unaccompanied-minor/guidance"
+  end
+
   def start
     render "unaccompanied-minor/start"
   end

--- a/app/views/unaccompanied-minor/guidance.html.erb
+++ b/app/views/unaccompanied-minor/guidance.html.erb
@@ -1,0 +1,123 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <a href="#" onclick="history.go(-1);return false;" class="govuk-back-link">Back</a>
+
+    <h1 class="govuk-heading-l">
+      Sponsor a child fleeing Ukraine without a parent
+    </h1>
+
+    <p>
+      Use this service to apply to sponsor a child fleeing Ukraine who is not accompanied by their legal guardian.
+    </p>
+    <p>
+      Unlike sponsoring an adult or a family, you will need to get parental consent and permission from your local council before you can apply for a visa.
+    </p>
+
+    <div id="step-by-step-navigation" class="app-step-nav app-step-nav--large app-step-nav--active" data-show-text="Show" data-hide-text="Hide" data-show-all-text="Show all" data-hide-all-text="Hide all"><div class="app-step-nav__controls"><button aria-expanded="false" class="app-step-nav__button app-step-nav__button--controls js-step-controls-button" aria-controls="step-panel-get-parental-consent-1">Show all</button></div>
+      <ol class="app-step-nav__steps">
+        <li class="app-step-nav__step js-step" id="get-parental-consent">
+          <div class="app-step-nav__header js-toggle-panel" data-position="1">
+            <h2 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="govuk-visually-hidden">Step</span> 1
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title"><button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="false" aria-controls="step-panel-get-parental-consent-1"><span class="js-step-title-text">
+                Get parental consent
+              </span><span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true" hidden="">Show</span></button></span>
+            </h2>
+          </div>
+
+          <div class="app-step-nav__panel js-panel js-hidden" id="step-panel-get-parental-consent-1">
+            <p class="app-step-nav__paragraph">At least one parent or legal guardian must consent to their child being sponsored. There are 2 forms they must complete:</p>
+
+            <ol class="app-step-nav__list " data-length="2">
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="1.1" class="app-step-nav__link js-link" href="#">Ukrainian consent form</a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="1.2" class="app-step-nav__link js-link" href="#">British consent form</a>
+              </li>
+            </ol>
+
+            <p class="app-step-nav__paragraph">Both forms need to be downloaded, completed and signed. The Ukrainian form also needs to be 'notarised'.</p>
+
+            <ol class="app-step-nav__list " data-length="1">
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="1.1" class="app-step-nav__link js-link" href="#">Find out how to complete the consent forms</a>
+              </li>
+            </ol>
+          </div>
+
+        </li>
+
+        <li class="app-step-nav__step js-step" id="get-permission-from-local-council">
+          <div class="app-step-nav__header js-toggle-panel" data-position="2">
+            <h2 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="govuk-visually-hidden">Step</span> 2
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title"><button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="false" aria-controls="step-panel-get-permission-from-local-council-2"><span class="js-step-title-text">
+                Get permission from your local council
+              </span><span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true" hidden="">Show</span></button></span>
+            </h2>
+          </div>
+            <p class="app-step-nav__paragraph">Before applying for a visa, the sponsor will need to get permission from their local council.</p>
+
+            <p class="app-step-nav__paragraph">The sponsor can apply for permission online. Their Local council will then perform a series of security checks, which include contacting the sponsor and parents.</p>
+
+            <p class="app-step-nav__paragraph">You will need to upload the parental consent forms from step 1 in this form.</p>
+
+          <div class="app-step-nav__panel js-panel js-hidden" id="step-panel-get-permission-from-local-council-2">
+            <ol class="app-step-nav__list " data-length="1">
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="2.1" class="app-step-nav__link js-link" href="/unaccompanied-minor/start">Apply for permission to sponsor an unaccompanied child fleeing Ukraine</a>
+              </li>
+            </ol>
+          </div>
+
+        </li>
+
+        <li class="app-step-nav__step js-step" id="apply-for-a-visa">
+          <div class="app-step-nav__header js-toggle-panel" data-position="3">
+            <h2 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="govuk-visually-hidden">Step</span> 3
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title"><button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="false" aria-controls="step-panel-apply-for-a-visa-3"><span class="js-step-title-text">
+                Apply for a visa
+              </span><span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true" hidden="">Show</span></button></span>
+            </h2>
+          </div>
+
+          <div class="app-step-nav__panel js-panel js-hidden" id="step-panel-apply-for-a-visa-3">
+            <p class="app-step-nav__paragraph">Lorem ipsum dolor sit amet.</p>
+
+            <ol class="app-step-nav__list " data-length="4">
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="3.1" class="app-step-nav__link js-link" href="#">Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</a>
+              </li>
+            </ol>
+          </div>
+
+        </li>
+      </ol>
+    </div>
+
+  </div>
+</div>

--- a/app/views/unaccompanied-minor/start.html.erb
+++ b/app/views/unaccompanied-minor/start.html.erb
@@ -4,16 +4,19 @@
     <a href="#" onclick="history.go(-1);return false;" class="govuk-back-link">Back</a>
 
     <h1 class="gem-c-title__text govuk-heading-l">
-      Apply for certification to sponsor a child travelling on their own
+      Apply for permission to sponsor a child fleeing Ukraine without a parent
     </h1>
 
-    <p class="gem-c-lead-paragraph">Use this service to apply for a certificate that shows you are suitable to sponsor a child who has been displaced from Ukraine.</p>
+    <p class="gem-c-lead-paragraph">Use this service to apply for permission to sponsor a child fleeing Ukraine who is not accompanied by their legal guardian.</p>
 
-    <p class="gem-c-lead-paragraph">You will need to submit one application per child you would like to sponsor.</p>
+    <p class="gem-c-lead-paragraph">You need to submit a separate application for each child you want to sponsor.</p>
+
+    <p class="gem-c-lead-paragraph">You must receive this permission before you can apply for a visa under the Ukraine Sponsorship Scheme (Homes for Ukraine).</p>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= govuk_button_link_to 'Start now', "/unaccompanied-minor/steps/1" %>
+        <a href="">Continue a saved application</a>
       </div>
     </div>
 
@@ -24,7 +27,9 @@
     <p class="gem-c-lead-paragraph">Make sure you have:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>a digital copy of your signed parental consent form</li>
+      <li>read and understood the process for sponsoring a child fleeing Ukraine without a parent</li>
+      <li>a digital copy of your signed British parental consent form</li>
+      <li>a digital copy of your signed and notarised Ukrainian parental consent form</li>
       <li>the full name and date of birth of the child you want to sponsor</li>
       <li>the full address where you and the child will stay in the UK</li>
     </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,8 @@ Rails.application.routes.draw do
   post "/additional-info/submit", to: "additional#submit"
   get "/additional-info/confirm", to: "additional#confirm"
 
-  get "/unaccompanied-minor", to: "unaccompanied#start"
+  get "/unaccompanied-minor", to: "unaccompanied#guidance"
+  get "/unaccompanied-minor/start", to: "unaccompanied#start"
   get "/unaccompanied-minor/steps/:stage", to: "unaccompanied#display"
   post "/unaccompanied-minor/steps/:stage", to: "unaccompanied#handle_step"
   get "/unaccompanied-minor/check-answers", to: "unaccompanied#check_answers"

--- a/spec/system/unaccompanied_minor_spec.rb
+++ b/spec/system/unaccompanied_minor_spec.rb
@@ -6,9 +6,18 @@ RSpec.describe "Unaccompanied minor expression of interest", type: :system do
   end
 
   describe "submitting the form" do
+    it "shows the guidance page before the start page" do
+      visit "/unaccompanied-minor/"
+      expect(page).to have_content("Sponsor a child fleeing Ukraine without a parent")
+
+      click_link("Apply for permission to sponsor an unaccompanied child fleeing Ukraine")
+
+      expect(page).to have_content("Apply for permission to sponsor a child fleeing Ukraine without a parent")
+    end
+
     it "without parental consent form terminates early" do
-      visit "/unaccompanied-minor"
-      expect(page).to have_content("Apply for certification to sponsor a child travelling on their own")
+      visit "/unaccompanied-minor/start"
+      expect(page).to have_content("Apply for permission to sponsor a child fleeing Ukraine without a parent")
 
       click_link("Start now")
 
@@ -28,8 +37,8 @@ RSpec.describe "Unaccompanied minor expression of interest", type: :system do
     end
 
     it "saves all of the answers in the database" do
-      visit "/unaccompanied-minor"
-      expect(page).to have_content("Apply for certification to sponsor a child travelling on their own")
+      visit "/unaccompanied-minor/start"
+      expect(page).to have_content("Apply for permission to sponsor a child fleeing Ukraine without a parent")
 
       click_link("Start now")
 


### PR DESCRIPTION
[Jira ticket](https://digital.dclg.gov.uk/jira/projects/UKRSS/issues/UKRSS-503)

- [x] Add a new guidance page (using GDS' step by step navigation pattern)
- [x] Update the copy on the existing Start page (now the second page in the flow)
- [x] Update `routes.rb` and `unaccompanied_minor.rb` controller

What's missing:

- [ ] Copy for `Apply for a visa`
- [ ] Links in guidance page