### PR TITLE
moving error summary up to top of page for DoB errors

### DIFF
--- a/app/views/sponsor-a-child/steps/18.html.erb
+++ b/app/views/sponsor-a-child/steps/18.html.erb
@@ -3,10 +3,11 @@
 
     <a href="#" onclick="history.go(-1);return false;" class="govuk-back-link">Back</a>
 
-    <h1 class="govuk-heading-l"><%= t('sponsor_date_of_birth.full', scope: "unaccompanied_minor.questions")%></h1>
-
     <%= form_for @application, url: "/sponsor-a-child/steps/18", method: :post do |f| %>
 
+    <%= f.govuk_error_summary link_base_errors_to: :sponsor_date_of_birth_day %>
+
+    <h1 class="govuk-heading-l"><%= t('sponsor_date_of_birth.full', scope: "unaccompanied_minor.questions")%></h1>
 
       <%= f.govuk_fieldset legend: { text: "", hidden: true }, hint: { text: 'For example, 31 3 2010' }, class: "govuk-date-input" do %>
 
@@ -23,7 +24,6 @@
             <%= f.govuk_text_field :sponsor_date_of_birth_year, label: { text: 'Year' }, type: "number", width: 4 %>
           </div>
         </div>
-        <%= f.govuk_error_summary link_base_errors_to: :sponsor_date_of_birth_day %>
 
       <% end %>
 

--- a/app/views/sponsor-a-child/steps/29.html.erb
+++ b/app/views/sponsor-a-child/steps/29.html.erb
@@ -3,6 +3,9 @@
 
     <a href="#" onclick="history.go(-1);return false;" class="govuk-back-link">Back</a>
 
+  <%= form_for @application, url: "/sponsor-a-child/steps/29/#{params["key"]}", method: :post do |f| %>
+    <%= f.govuk_error_summary link_base_errors_to: :adult_date_of_birth_day %>
+
     <h1 class="gem-c-title__text govuk-heading-l">
       Enter this person's date of birth
     </h1>
@@ -11,7 +14,6 @@
       <%= "#{@adult["given_name"]} #{@adult["family_name"]}" %>
     </div>
 
-    <%= form_for @application, url: "/sponsor-a-child/steps/29/#{params["key"]}", method: :post do |f| %>
 
       <%= f.govuk_fieldset legend: { text: t("minor_date_of_birth.full", :name => "#{@adult["given_name"]} #{@adult["family_name"]}", scope: "unaccompanied_minor.questions"), size: "m", hidden: true } do %>
 
@@ -26,8 +28,7 @@
             <%= f.govuk_text_field :adult_date_of_birth_year, label: { text: "Year" }, type: "number", width: 4 %>
           </div>
         </div>
-        <%= f.govuk_error_summary link_base_errors_to: :adult_date_of_birth_day %>
-
+      
       <% end %>
 
       <%= f.govuk_submit t("continue") %>

--- a/app/views/sponsor-a-child/steps/34.html.erb
+++ b/app/views/sponsor-a-child/steps/34.html.erb
@@ -3,6 +3,9 @@
 
     <a href="#" onclick="history.go(-1);return false;" class="govuk-back-link">Back</a>
 
+     <%= form_for @application, url: "/sponsor-a-child/steps/34", method: :post do |f| %>
+     <%= f.govuk_error_summary link_base_errors_to: :minor_date_of_birth_day %>
+
     <h1 class="gem-c-title__text govuk-heading-l">
       Enter their date of birth
     </h1>
@@ -11,8 +14,6 @@
     <%=@application.minor_full_name?%>
 
     </div>
-
-    <%= form_for @application, url: "/sponsor-a-child/steps/34", method: :post do |f| %>
 
       <%= f.govuk_fieldset legend: { text: "", hidden: true }, hint: { text: 'For example, 31 3 2010' }, class: "govuk-date-input" do %>
 
@@ -29,7 +30,6 @@
             <%= f.govuk_text_field :minor_date_of_birth_year, label: { text: 'Year' }, type: "number", width: 4 %>
           </div>
         </div>
-        <%= f.govuk_error_summary link_base_errors_to: :minor_date_of_birth_day %>
 
       <% end %>
 


### PR DESCRIPTION
Just moving the headers inside the form and then the error summary above the headers in accordance with GDS 