### PR TITLE
Enable remove option for sponsor other nationalities

### DIFF
--- a/app/controllers/unaccompanied_controller.rb
+++ b/app/controllers/unaccompanied_controller.rb
@@ -525,6 +525,24 @@ class UnaccompaniedController < ApplicationController
     end
   end
 
+  def remove_other_nationality
+    @application = UnaccompaniedMinor.find_by_reference(session[:app_reference])
+    @application.other_nationalities = @application.other_nationalities.delete_if{|entry| entry[0].split.first == params["country_code"]}
+
+    if @application.other_nationalities.length.zero?
+      @application.has_other_nationalities = "false"
+      @application.other_nationalities = nil
+    end
+
+    @application.update!(@application.as_json)
+
+    if @application.other_nationalities.blank?
+      redirect_to TASK_LIST_URI
+    else
+      redirect_to "/sponsor-a-child/steps/22"
+    end
+  end
+
 private
 
   def check_last_activity

--- a/app/controllers/unaccompanied_controller.rb
+++ b/app/controllers/unaccompanied_controller.rb
@@ -527,7 +527,7 @@ class UnaccompaniedController < ApplicationController
 
   def remove_other_nationality
     @application = UnaccompaniedMinor.find_by_reference(session[:app_reference])
-    @application.other_nationalities = @application.other_nationalities.delete_if{|entry| entry[0].split.first == params["country_code"]}
+    @application.other_nationalities = @application.other_nationalities.delete_if { |entry| entry[0].split.first == params["country_code"] }
 
     if @application.other_nationalities.length.zero?
       @application.has_other_nationalities = "false"

--- a/app/views/sponsor-a-child/steps/22.html.erb
+++ b/app/views/sponsor-a-child/steps/22.html.erb
@@ -7,17 +7,16 @@
     <h1 class="govuk-heading-l">You have added <%= @application.other_nationalities.length() %> other nationalities</h1>
 
     <table class="govuk-table">
-        <% @application.other_nationalities.each_with_index do |nationality, index| %>
         <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Other nationalities (<%= index+1 %>)</th>
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Other nationalities</th>
             <th scope="col" class="govuk-table__header"></th>
-            </tr>
+          </tr>
         </thead>
         <tbody class="govuk-table__body">
+            <% @application.other_nationalities.each_with_index do |nationality, index| %>
             <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header">Nationality</th>
-            <td class="govuk-table__cell"><%= nationality[0] %></td>
+              <td class="govuk-table__cell"><%= nationality[0] %></td>
             </tr>
         </tbody>
         <% end %>

--- a/app/views/sponsor-a-child/steps/22.html.erb
+++ b/app/views/sponsor-a-child/steps/22.html.erb
@@ -14,9 +14,12 @@
           </tr>
         </thead>
         <tbody class="govuk-table__body">
-            <% @application.other_nationalities.each_with_index do |nationality, index| %>
+            <% @application.other_nationalities.each do |nationality| %>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><%= nationality[0] %></td>
+              <td class="govuk-table__cell">
+                <%= link_to("Remove", "/sponsor-a-child/remove-other-nationality/#{nationality[0].split.first}") %>
+              </td>
             </tr>
         </tbody>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
   post "/sponsor-a-child/upload-ukraine/:stage", to: "unaccompanied#handle_upload_ukraine"
   get "/sponsor-a-child/remove/:key", to: "unaccompanied#remove_adult"
   get "/sponsor-a-child/remove-other-name/:given_name/:family_name", to: "unaccompanied#remove_other_sponsor_name"
+  get "/sponsor-a-child/remove-other-nationality/:country_code", to: "unaccompanied#remove_other_nationality"
 
   get "/sponsor-a-child/resume-application", to: "token_based_resume#display"
   post "/sponsor-a-child/resume-application", to: "token_based_resume#submit"

--- a/spec/system/unaccompanied_minor_sponsor_other_nationalities_spec.rb
+++ b/spec/system/unaccompanied_minor_sponsor_other_nationalities_spec.rb
@@ -84,5 +84,43 @@ RSpec.describe "Unaccompanied minor sponsor other nationalities", type: :system 
       click_link("Continue")
       expect(page).to have_content(task_list_content)
     end
+
+    it "when other nationalities are added and removed" do
+      task_list_to_other_nationalities_question
+
+      choose("Yes")
+      click_button("Continue")
+
+      expect(page).to have_content("What is your other nationality?")
+
+      select("Albania", from: "unaccompanied-minor-other-nationality-field")
+      click_button("Continue")
+
+      expect(page).to have_content("You have added 1 other nationalit")
+      expect(page).to have_content("ALB - Albania")
+
+      expected_first_remove_url = "/sponsor-a-child/remove-other-nationality/ALB".freeze
+      expect(page).to have_link("Remove", href: expected_first_remove_url)
+
+      click_link("Add another nationality")
+
+      expect(page).to have_content("What is your other nationality?")
+
+      select("Algeria", from: "unaccompanied-minor-other-nationality-field")
+      click_button("Continue")
+
+      expect(page).to have_content("You have added 2 other nationalit")
+      expect(page).to have_content("DZA - Algeria")
+
+      expected_second_remove_url = "/sponsor-a-child/remove-other-nationality/DZA".freeze
+      expect(page).to have_link("Remove", href: expected_second_remove_url)
+
+      click_link(href: expected_second_remove_url)
+      expect(page).to have_content("You have added 1 other nationalit")
+      expect(page).not_to have_content("DZA - Algeria")
+
+      click_link(href: expected_first_remove_url)
+      expect(page).to have_content(task_list_content)
+    end
   end
 end

--- a/spec/system/unaccompanied_minor_sponsor_other_nationalities_spec.rb
+++ b/spec/system/unaccompanied_minor_sponsor_other_nationalities_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Unaccompanied minor sponsor other nationalities", type: :system 
       expect(page).to have_content(task_list_content)
     end
 
-    it "when other nationalities are added and all removed" do
+    it "when other nationalities are added and all removed, return to the task list" do
       task_list_to_other_nationalities_question
       add_two_extra_nationalities
 

--- a/spec/system/unaccompanied_minor_sponsor_other_nationalities_spec.rb
+++ b/spec/system/unaccompanied_minor_sponsor_other_nationalities_spec.rb
@@ -7,14 +7,46 @@ RSpec.describe "Unaccompanied minor sponsor other nationalities", type: :system 
   end
 
   describe "sponsor enters other names" do
-    let(:task_list_content) { "Apply for permission to sponsor a child fleeing Ukraine without a parent".freeze }
+    let(:expected_algeria_added_copy) { "DZA - Algeria".freeze }
+    let(:expected_second_remove_url) { "/sponsor-a-child/remove-other-nationality/DZA".freeze }
+    let(:expected_first_remove_url) { "/sponsor-a-child/remove-other-nationality/ALB".freeze }
     let(:main_nationality) { "Afghanistan".freeze }
+    let(:task_list_content) { "Apply for permission to sponsor a child fleeing Ukraine without a parent".freeze }
 
     before do
       application = UnaccompaniedMinor.new
       application.save!
 
       page.set_rack_session(app_reference: application.reference)
+    end
+
+    it "when no other nationalities are added go to task list" do
+      task_list_to_other_nationalities_question
+
+      choose("No")
+      click_button("Continue")
+      expect(page).to have_content(task_list_content)
+    end
+
+    it "when other nationalities are added and not removed clicking continue returns to task list" do
+      task_list_to_other_nationalities_question
+      add_two_extra_nationalities
+
+      click_link("Continue")
+      expect(page).to have_content(task_list_content)
+    end
+
+    it "when other nationalities are added and all removed" do
+      task_list_to_other_nationalities_question
+      add_two_extra_nationalities
+
+      click_link(href: expected_second_remove_url)
+      expect(page).to have_content("You have added 1 other nationalit")
+      expect(page).not_to have_content(expected_algeria_added_copy)
+
+      click_link(href: expected_first_remove_url)
+
+      expect(page).to have_content(task_list_content)
     end
 
     def task_list_to_other_nationalities_question
@@ -43,51 +75,7 @@ RSpec.describe "Unaccompanied minor sponsor other nationalities", type: :system 
       expect(page).to have_content("Have you ever held any other nationalities?")
     end
 
-    it "when no other nationalities are added go to task list" do
-      task_list_to_other_nationalities_question
-
-      choose("No")
-      click_button("Continue")
-      expect(page).to have_content(task_list_content)
-    end
-
-    it "when other nationalities are added" do
-      task_list_to_other_nationalities_question
-
-      choose("Yes")
-      click_button("Continue")
-
-      expect(page).to have_content("What is your other nationality?")
-
-      select("Albania", from: "unaccompanied-minor-other-nationality-field")
-      click_button("Continue")
-
-      expect(page).to have_content("You have added 1 other nationalities")
-      expect(page).to have_content("ALB - Albania")
-
-      expected_first_remove_url = "/sponsor-a-child/remove-other-nationality/ALB".freeze
-      expect(page).to have_link("Remove", href: expected_first_remove_url)
-
-      click_link("Add another nationality")
-
-      expect(page).to have_content("What is your other nationality?")
-
-      select("Algeria", from: "unaccompanied-minor-other-nationality-field")
-      click_button("Continue")
-
-      expect(page).to have_content("You have added 2 other nationalities")
-      expect(page).to have_content("DZA - Algeria")
-
-      expected_second_remove_url = "/sponsor-a-child/remove-other-nationality/DZA".freeze
-      expect(page).to have_link("Remove", href: expected_second_remove_url)
-
-      click_link("Continue")
-      expect(page).to have_content(task_list_content)
-    end
-
-    it "when other nationalities are added and removed" do
-      task_list_to_other_nationalities_question
-
+    def add_two_extra_nationalities
       choose("Yes")
       click_button("Continue")
 
@@ -98,8 +86,6 @@ RSpec.describe "Unaccompanied minor sponsor other nationalities", type: :system 
 
       expect(page).to have_content("You have added 1 other nationalit")
       expect(page).to have_content("ALB - Albania")
-
-      expected_first_remove_url = "/sponsor-a-child/remove-other-nationality/ALB".freeze
       expect(page).to have_link("Remove", href: expected_first_remove_url)
 
       click_link("Add another nationality")
@@ -110,17 +96,8 @@ RSpec.describe "Unaccompanied minor sponsor other nationalities", type: :system 
       click_button("Continue")
 
       expect(page).to have_content("You have added 2 other nationalit")
-      expect(page).to have_content("DZA - Algeria")
-
-      expected_second_remove_url = "/sponsor-a-child/remove-other-nationality/DZA".freeze
+      expect(page).to have_content(expected_algeria_added_copy)
       expect(page).to have_link("Remove", href: expected_second_remove_url)
-
-      click_link(href: expected_second_remove_url)
-      expect(page).to have_content("You have added 1 other nationalit")
-      expect(page).not_to have_content("DZA - Algeria")
-
-      click_link(href: expected_first_remove_url)
-      expect(page).to have_content(task_list_content)
     end
   end
 end

--- a/spec/system/unaccompanied_minor_sponsor_other_nationalities_spec.rb
+++ b/spec/system/unaccompanied_minor_sponsor_other_nationalities_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Unaccompanied minor sponsor other nationalities", type: :system 
     driven_by(:rack_test_user_agent)
   end
 
-  describe "sponsor enters other names" do
+  describe "sponsor enters other nationalities" do
     let(:expected_algeria_added_copy) { "DZA - Algeria".freeze }
     let(:expected_second_remove_url) { "/sponsor-a-child/remove-other-nationality/DZA".freeze }
     let(:expected_first_remove_url) { "/sponsor-a-child/remove-other-nationality/ALB".freeze }

--- a/spec/system/unaccompanied_minor_sponsor_other_nationalities_spec.rb
+++ b/spec/system/unaccompanied_minor_sponsor_other_nationalities_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+require "securerandom"
+
+RSpec.describe "Unaccompanied minor sponsor other nationalities", type: :system do
+  before do
+    driven_by(:rack_test_user_agent)
+  end
+
+  describe "sponsor enters other names" do
+    let(:task_list_content) { "Apply for permission to sponsor a child fleeing Ukraine without a parent".freeze }
+    let(:first_nationality) { "Firstextra".freeze }
+
+    before do
+      application = UnaccompaniedMinor.new
+      application.save!
+
+      page.set_rack_session(app_reference: application.reference)
+    end
+
+    def task_list_to_other_nationalities_question
+      visit "/sponsor-a-child/task-list"
+      expect(page).to have_content(task_list_content)
+
+      click_link("Additional details")
+      expect(page).to have_content("Do you have any of these identity documents?")
+
+      choose(option: "passport")
+      fill_in("Passport number", with: "123456789")
+      click_button("Continue")
+
+      expect(page).to have_content("Enter your date of birth")
+
+      fill_in("Day", with: "1")
+      fill_in("Month", with: "1")
+      fill_in("Year", with: "2000")
+      click_button("Continue")
+
+      expect(page).to have_content("Enter your nationality")
+
+      select("Afghanistan", from: "unaccompanied-minor-nationality-field")
+      click_button("Continue")
+
+      expect(page).to have_content("Have you ever held any other nationalities?")
+    end
+
+    it "when no other nationalities are added go to task list" do
+      task_list_to_other_nationalities_question
+
+      choose("No")
+      click_button("Continue")
+      expect(page).to have_content(task_list_content)
+    end
+
+    # it "when other nationalities are added" do
+    #  #task list
+    #  # click additional details
+    #  # docs - passport + "123456789" => continue
+    #  # date of birth 2000-1-1 => continue
+    #  # Nationality Afgan - contiue
+    #  # Others - yes, continue
+    #  # Add one
+    #  # Should show with a remove link
+    # end
+
+    # it "when other names are entered and all removed" do
+    # end
+  end
+end

--- a/spec/system/unaccompanied_minor_sponsor_other_nationalities_spec.rb
+++ b/spec/system/unaccompanied_minor_sponsor_other_nationalities_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Unaccompanied minor sponsor other nationalities", type: :system 
 
   describe "sponsor enters other names" do
     let(:task_list_content) { "Apply for permission to sponsor a child fleeing Ukraine without a parent".freeze }
-    let(:first_nationality) { "Firstextra".freeze }
+    let(:main_nationality) { "Afghanistan".freeze }
 
     before do
       application = UnaccompaniedMinor.new
@@ -37,7 +37,7 @@ RSpec.describe "Unaccompanied minor sponsor other nationalities", type: :system 
 
       expect(page).to have_content("Enter your nationality")
 
-      select("Afghanistan", from: "unaccompanied-minor-nationality-field")
+      select(main_nationality, from: "unaccompanied-minor-nationality-field")
       click_button("Continue")
 
       expect(page).to have_content("Have you ever held any other nationalities?")
@@ -51,18 +51,38 @@ RSpec.describe "Unaccompanied minor sponsor other nationalities", type: :system 
       expect(page).to have_content(task_list_content)
     end
 
-    # it "when other nationalities are added" do
-    #  #task list
-    #  # click additional details
-    #  # docs - passport + "123456789" => continue
-    #  # date of birth 2000-1-1 => continue
-    #  # Nationality Afgan - contiue
-    #  # Others - yes, continue
-    #  # Add one
-    #  # Should show with a remove link
-    # end
+    it "when other nationalities are added" do
+      task_list_to_other_nationalities_question
 
-    # it "when other names are entered and all removed" do
-    # end
+      choose("Yes")
+      click_button("Continue")
+
+      expect(page).to have_content("What is your other nationality?")
+
+      select("Albania", from: "unaccompanied-minor-other-nationality-field")
+      click_button("Continue")
+
+      expect(page).to have_content("You have added 1 other nationalities")
+      expect(page).to have_content("ALB - Albania")
+
+      expected_first_remove_url = "/sponsor-a-child/remove-other-nationality/ALB".freeze
+      expect(page).to have_link("Remove", href: expected_first_remove_url)
+
+      click_link("Add another nationality")
+
+      expect(page).to have_content("What is your other nationality?")
+
+      select("Algeria", from: "unaccompanied-minor-other-nationality-field")
+      click_button("Continue")
+
+      expect(page).to have_content("You have added 2 other nationalities")
+      expect(page).to have_content("DZA - Algeria")
+
+      expected_second_remove_url = "/sponsor-a-child/remove-other-nationality/DZA".freeze
+      expect(page).to have_link("Remove", href: expected_second_remove_url)
+
+      click_link("Continue")
+      expect(page).to have_content(task_list_content)
+    end
   end
 end


### PR DESCRIPTION
This pr covers adding remove option for sponsors other **nationalities** in [Jira ticket 783](https://digital.dclg.gov.uk/jira/browse/UKRSS-783)

* Remove link added
* Layout is consistent with residents page

![image](https://user-images.githubusercontent.com/1417516/182824058-55e70eba-2c39-4a84-b066-cd354d15e10d.png)


