### PR TITLE
500 Upload consents - delete tmp files

### DIFF
--- a/app/controllers/foundry_consent_upload_controller.rb
+++ b/app/controllers/foundry_consent_upload_controller.rb
@@ -13,7 +13,8 @@ class FoundryConsentUploadController < ApplicationController
     uam = UnaccompaniedMinor.find_by_reference(params["consent"]["reference"])
 
     begin
-      TransferRecord.execute_unaccompanied_minor_consent_forms(uam.id)
+      consent_uploader = TransferConsents.new
+      consent_uploader.send(uam.id)
     rescue StandardError => e
       Rails.logger.debug "****************************************************************"
       Rails.logger.debug "Test upload errors: #{e.message}"

--- a/app/jobs/send_unaccompanied_minor_job.rb
+++ b/app/jobs/send_unaccompanied_minor_job.rb
@@ -6,7 +6,8 @@ class SendUnaccompaniedMinorJob < ApplicationJob
     TransferRecord.execute_unaccompanied_minor(id)
 
     if ENV["UAM_FEATURE_TRANSFER_CONSENT_FORMS"] == "true"
-      TransferRecord.execute_unaccompanied_minor_consent_forms(id)
+      consent_uploader = TransferConsents.new
+      consent_uploader.send(id)
     end
   end
 end

--- a/app/use-cases/transfer_consents.rb
+++ b/app/use-cases/transfer_consents.rb
@@ -11,20 +11,14 @@ class TransferConsents
     uam = UnaccompaniedMinor.find(record_id)
 
     begin
-      # UK
-      file_path = @storage.download(uam.uk_parental_consent_saved_filename)
-      rid = @uploader.upload(file_path, uam.uk_parental_consent_filename)
-      @foundry.assign_uploaded_uk_consent_form(uam.reference, rid)
-
-      uam.uk_parental_consent_file_upload_rid = rid
+      uk_rid = transfer(uam.uk_parental_consent_saved_filename, uam.uk_parental_consent_filename)
+      @foundry.assign_uploaded_uk_consent_form(uam.reference, uk_rid)
+      uam.uk_parental_consent_file_upload_rid = uk_rid
       uam.uk_parental_consent_file_uploaded_timestamp = Time.zone.now.utc
 
-      # UA
-      ua_file_path = @storage.download(uam.ukraine_parental_consent_saved_filename)
-      ua_rid = @uploader.upload(ua_file_path, uam.ukraine_parental_consent_filename)
-      @foundry.assign_uploaded_ukraine_consent_form(uam.reference, ua_rid)
-
-      uam.ukraine_parental_consent_file_upload_rid = ua_rid
+      ukraine_rid = transfer(uam.ukraine_parental_consent_saved_filename, uam.ukraine_parental_consent_filename)
+      @foundry.assign_uploaded_ukraine_consent_form(uam.reference, ukraine_rid)
+      uam.ukraine_parental_consent_file_upload_rid = ukraine_rid
       uam.ukraine_parental_consent_file_uploaded_timestamp = Time.zone.now.utc
 
       uam.save!(validate: false)
@@ -32,5 +26,12 @@ class TransferConsents
       Rails.logger.error "Error uploading consent forms. #{e.message}"
       raise e
     end
+  end
+
+private
+
+  def transfer(s3_filename, actual_filename)
+    file_path = @storage.download(s3_filename)
+    @uploader.upload(file_path, actual_filename)
   end
 end

--- a/app/use-cases/transfer_consents.rb
+++ b/app/use-cases/transfer_consents.rb
@@ -1,0 +1,51 @@
+require "net/http"
+
+class TransferConsents
+  def initialize; end
+
+  def self.execute_unaccompanied_minor_consent_forms(record_id, storage_service = nil, upload_service = nil, foundry = nil)
+    Rails.logger.info "Uploading consent forms for record: #{record_id}"
+
+    storage_service ||= StorageService.new(PaasConfigurationService.new, ENV["INSTANCE_NAME"])
+    upload_service ||= FileUploadService.new
+    foundry ||= FoundryService.new
+
+    begin
+      uam = UnaccompaniedMinor.find(record_id)
+
+      # UK
+      file_path = storage_service.download(uam.uk_parental_consent_saved_filename)
+      rid = upload_service.upload(file_path, uam.uk_parental_consent_filename)
+      foundry.assign_uploaded_uk_consent_form(uam.reference, rid)
+
+      uam.uk_parental_consent_file_upload_rid = rid
+      uam.uk_parental_consent_file_uploaded_timestamp = Time.zone.now.utc
+
+      # UA
+      ua_file_path = storage_service.download(uam.ukraine_parental_consent_saved_filename)
+      ua_rid = upload_service.upload(ua_file_path, uam.ukraine_parental_consent_filename)
+      foundry.assign_uploaded_ukraine_consent_form(uam.reference, ua_rid)
+
+      uam.ukraine_parental_consent_file_upload_rid = ua_rid
+      uam.ukraine_parental_consent_file_uploaded_timestamp = Time.zone.now.utc
+
+      uam.save!(validate: false)
+    rescue StandardError => e
+      Rails.logger.error "Error uploading consent forms. #{e.message}"
+      raise e
+    end
+  end
+
+  def self.execute_unaccompanied_minor_uk_consent(record_id)
+    Rails.logger.info "Uploading uk consent for record: #{record_id}"
+  end
+
+  def self.execute_unaccompanied_minor_ukraine_consent(record_id)
+    Rails.logger.info "Uploading ukraine consent for record: #{record_id}"
+
+    # @application.ukraine_parental_consent_file_type
+    # @application.ukraine_parental_consent_filename
+    # @application.ukraine_parental_consent_saved_filename
+    # @application.ukraine_parental_consent_file_size
+  end
+end

--- a/app/use-cases/transfer_consents.rb
+++ b/app/use-cases/transfer_consents.rb
@@ -10,25 +10,27 @@ class TransferConsents
   def send(record_id)
     uam = UnaccompaniedMinor.find(record_id)
 
-    # UK
-    file_path = @storage.download(uam.uk_parental_consent_saved_filename)
-    rid = @uploader.upload(file_path, uam.uk_parental_consent_filename)
-    @foundry.assign_uploaded_uk_consent_form(uam.reference, rid)
+    begin
+      # UK
+      file_path = @storage.download(uam.uk_parental_consent_saved_filename)
+      rid = @uploader.upload(file_path, uam.uk_parental_consent_filename)
+      @foundry.assign_uploaded_uk_consent_form(uam.reference, rid)
 
-    uam.uk_parental_consent_file_upload_rid = rid
-    uam.uk_parental_consent_file_uploaded_timestamp = Time.zone.now.utc
+      uam.uk_parental_consent_file_upload_rid = rid
+      uam.uk_parental_consent_file_uploaded_timestamp = Time.zone.now.utc
 
-    # UA
-    ua_file_path = @storage.download(uam.ukraine_parental_consent_saved_filename)
-    ua_rid = @uploader.upload(ua_file_path, uam.ukraine_parental_consent_filename)
-    @foundry.assign_uploaded_ukraine_consent_form(uam.reference, ua_rid)
+      # UA
+      ua_file_path = @storage.download(uam.ukraine_parental_consent_saved_filename)
+      ua_rid = @uploader.upload(ua_file_path, uam.ukraine_parental_consent_filename)
+      @foundry.assign_uploaded_ukraine_consent_form(uam.reference, ua_rid)
 
-    uam.ukraine_parental_consent_file_upload_rid = ua_rid
-    uam.ukraine_parental_consent_file_uploaded_timestamp = Time.zone.now.utc
+      uam.ukraine_parental_consent_file_upload_rid = ua_rid
+      uam.ukraine_parental_consent_file_uploaded_timestamp = Time.zone.now.utc
 
-    uam.save!(validate: false)
-  rescue StandardError => e
-    Rails.logger.error "Error uploading consent forms. #{e.message}"
-    raise e
+      uam.save!(validate: false)
+    rescue StandardError => e
+      Rails.logger.error "Error uploading consent forms. #{e.message}"
+      raise e
+    end
   end
 end

--- a/app/use-cases/transfer_consents.rb
+++ b/app/use-cases/transfer_consents.rb
@@ -31,11 +31,4 @@ class TransferConsents
     Rails.logger.error "Error uploading consent forms. #{e.message}"
     raise e
   end
-
-  def self.execute_unaccompanied_minor_consent_forms(record_id, storage_service = nil, upload_service = nil, foundry = nil)
-    Rails.logger.info "Uploading consent forms for record: #{record_id}"
-
-    consent_uploader = TransferConsents.new(storage_service, upload_service, foundry)
-    consent_uploader.send(record_id)
-  end
 end

--- a/app/use-cases/transfer_consents.rb
+++ b/app/use-cases/transfer_consents.rb
@@ -32,6 +32,15 @@ private
 
   def transfer(s3_filename, actual_filename)
     file_path = @storage.download(s3_filename)
-    @uploader.upload(file_path, actual_filename)
+    rid = @uploader.upload(file_path, actual_filename)
+
+    begin
+      File.delete(file_path) if File.exist?(file_path)
+    rescue StandardError => e
+      # best effort only
+      Rails.logger.error "Error deleting temp file:#{file_path} Message:#{e.message}"
+    end
+
+    rid
   end
 end

--- a/app/use-cases/transfer_consents.rb
+++ b/app/use-cases/transfer_consents.rb
@@ -1,51 +1,41 @@
 require "net/http"
 
 class TransferConsents
-  def initialize; end
+  def initialize(storage_service = nil, upload_service = nil, foundry_service = nil)
+    @storage = storage_service || StorageService.new(PaasConfigurationService.new, ENV["INSTANCE_NAME"])
+    @uploader = upload_service || FileUploadService.new
+    @foundry = foundry_service || FoundryService.new
+  end
+
+  def send(record_id)
+    uam = UnaccompaniedMinor.find(record_id)
+
+    # UK
+    file_path = @storage.download(uam.uk_parental_consent_saved_filename)
+    rid = @uploader.upload(file_path, uam.uk_parental_consent_filename)
+    @foundry.assign_uploaded_uk_consent_form(uam.reference, rid)
+
+    uam.uk_parental_consent_file_upload_rid = rid
+    uam.uk_parental_consent_file_uploaded_timestamp = Time.zone.now.utc
+
+    # UA
+    ua_file_path = @storage.download(uam.ukraine_parental_consent_saved_filename)
+    ua_rid = @uploader.upload(ua_file_path, uam.ukraine_parental_consent_filename)
+    @foundry.assign_uploaded_ukraine_consent_form(uam.reference, ua_rid)
+
+    uam.ukraine_parental_consent_file_upload_rid = ua_rid
+    uam.ukraine_parental_consent_file_uploaded_timestamp = Time.zone.now.utc
+
+    uam.save!(validate: false)
+  rescue StandardError => e
+    Rails.logger.error "Error uploading consent forms. #{e.message}"
+    raise e
+  end
 
   def self.execute_unaccompanied_minor_consent_forms(record_id, storage_service = nil, upload_service = nil, foundry = nil)
     Rails.logger.info "Uploading consent forms for record: #{record_id}"
 
-    storage_service ||= StorageService.new(PaasConfigurationService.new, ENV["INSTANCE_NAME"])
-    upload_service ||= FileUploadService.new
-    foundry ||= FoundryService.new
-
-    begin
-      uam = UnaccompaniedMinor.find(record_id)
-
-      # UK
-      file_path = storage_service.download(uam.uk_parental_consent_saved_filename)
-      rid = upload_service.upload(file_path, uam.uk_parental_consent_filename)
-      foundry.assign_uploaded_uk_consent_form(uam.reference, rid)
-
-      uam.uk_parental_consent_file_upload_rid = rid
-      uam.uk_parental_consent_file_uploaded_timestamp = Time.zone.now.utc
-
-      # UA
-      ua_file_path = storage_service.download(uam.ukraine_parental_consent_saved_filename)
-      ua_rid = upload_service.upload(ua_file_path, uam.ukraine_parental_consent_filename)
-      foundry.assign_uploaded_ukraine_consent_form(uam.reference, ua_rid)
-
-      uam.ukraine_parental_consent_file_upload_rid = ua_rid
-      uam.ukraine_parental_consent_file_uploaded_timestamp = Time.zone.now.utc
-
-      uam.save!(validate: false)
-    rescue StandardError => e
-      Rails.logger.error "Error uploading consent forms. #{e.message}"
-      raise e
-    end
-  end
-
-  def self.execute_unaccompanied_minor_uk_consent(record_id)
-    Rails.logger.info "Uploading uk consent for record: #{record_id}"
-  end
-
-  def self.execute_unaccompanied_minor_ukraine_consent(record_id)
-    Rails.logger.info "Uploading ukraine consent for record: #{record_id}"
-
-    # @application.ukraine_parental_consent_file_type
-    # @application.ukraine_parental_consent_filename
-    # @application.ukraine_parental_consent_saved_filename
-    # @application.ukraine_parental_consent_file_size
+    consent_uploader = TransferConsents.new(storage_service, upload_service, foundry)
+    consent_uploader.send(record_id)
   end
 end

--- a/app/use-cases/transfer_record.rb
+++ b/app/use-cases/transfer_record.rb
@@ -63,11 +63,4 @@ class TransferRecord
       end
     end
   end
-
-  def self.execute_unaccompanied_minor_consent_forms(record_id)
-    Rails.logger.info "Uploading consent forms for record: #{record_id}"
-
-    consent_uploader = TransferConsents.new
-    consent_uploader.send(record_id)
-  end
 end

--- a/app/use-cases/transfer_record.rb
+++ b/app/use-cases/transfer_record.rb
@@ -71,42 +71,6 @@ class TransferRecord
     upload_service ||= FileUploadService.new
     foundry ||= FoundryService.new
 
-    begin
-      uam = UnaccompaniedMinor.find(record_id)
-
-      # UK
-      file_path = storage_service.download(uam.uk_parental_consent_saved_filename)
-      rid = upload_service.upload(file_path, uam.uk_parental_consent_filename)
-      foundry.assign_uploaded_uk_consent_form(uam.reference, rid)
-
-      uam.uk_parental_consent_file_upload_rid = rid
-      uam.uk_parental_consent_file_uploaded_timestamp = Time.zone.now.utc
-
-      # UA
-      ua_file_path = storage_service.download(uam.ukraine_parental_consent_saved_filename)
-      ua_rid = upload_service.upload(ua_file_path, uam.ukraine_parental_consent_filename)
-      foundry.assign_uploaded_ukraine_consent_form(uam.reference, ua_rid)
-
-      uam.ukraine_parental_consent_file_upload_rid = ua_rid
-      uam.ukraine_parental_consent_file_uploaded_timestamp = Time.zone.now.utc
-
-      uam.save!(validate: false)
-    rescue StandardError => e
-      Rails.logger.error "Error uploading consent forms. #{e.message}"
-      raise e
-    end
-  end
-
-  def self.execute_unaccompanied_minor_uk_consent(record_id)
-    Rails.logger.info "Uploading uk consent for record: #{record_id}"
-  end
-
-  def self.execute_unaccompanied_minor_ukraine_consent(record_id)
-    Rails.logger.info "Uploading ukraine consent for record: #{record_id}"
-
-    # @application.ukraine_parental_consent_file_type
-    # @application.ukraine_parental_consent_filename
-    # @application.ukraine_parental_consent_saved_filename
-    # @application.ukraine_parental_consent_file_size
+    TransferConsents.execute_unaccompanied_minor_consent_forms(record_id, storage_service, upload_service, foundry)
   end
 end

--- a/app/use-cases/transfer_record.rb
+++ b/app/use-cases/transfer_record.rb
@@ -64,14 +64,10 @@ class TransferRecord
     end
   end
 
-  def self.execute_unaccompanied_minor_consent_forms(record_id, storage_service = nil, upload_service = nil, foundry = nil)
+  def self.execute_unaccompanied_minor_consent_forms(record_id)
     Rails.logger.info "Uploading consent forms for record: #{record_id}"
 
-    storage_service ||= StorageService.new(PaasConfigurationService.new, ENV["INSTANCE_NAME"])
-    upload_service ||= FileUploadService.new
-    foundry ||= FoundryService.new
-
-    consent_uploader = TransferConsents.new(storage_service, upload_service, foundry)
+    consent_uploader = TransferConsents.new
     consent_uploader.send(record_id)
   end
 end

--- a/app/use-cases/transfer_record.rb
+++ b/app/use-cases/transfer_record.rb
@@ -71,6 +71,7 @@ class TransferRecord
     upload_service ||= FileUploadService.new
     foundry ||= FoundryService.new
 
-    TransferConsents.execute_unaccompanied_minor_consent_forms(record_id, storage_service, upload_service, foundry)
+    consent_uploader = TransferConsents.new(storage_service, upload_service, foundry)
+    consent_uploader.send(record_id)
   end
 end

--- a/spec/controllers/use-cases/transfer_consents_spec.rb
+++ b/spec/controllers/use-cases/transfer_consents_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe TransferRecord, type: :feature do
+RSpec.describe TransferConsents, type: :feature do
   describe "transferring consent forms" do
     let(:foundry_service) { instance_double("FoundryService") }
     let(:storage_service) { instance_double("StorageService") }
@@ -48,8 +48,9 @@ RSpec.describe TransferRecord, type: :feature do
       .with(uam.reference, ukraine_rid)
     end
 
-    it "uploads the uk consent form" do
-      described_class.execute_unaccompanied_minor_consent_forms(uam.id, storage_service, file_upload_service, foundry_service)
+    it "uploads the uk and ukraine consent forms" do
+      transfer_consents = described_class.new(storage_service, file_upload_service, foundry_service)
+      transfer_consents.send(uam.id)
 
       expect(UnaccompaniedMinor).to have_received(:find).with(uam.id)
 


### PR DESCRIPTION
- Added a "safe" deletion of downloaded tmp files 
- Extracted a class TransferConsents, from TransferRecord, and test directly
    - Cleans `transfer record` "job" class to a standard pattern
