### PR TITLE
839 - Sponsor residential address validation

### DIFF
--- a/app/models/concerns/uam_validations.rb
+++ b/app/models/concerns/uam_validations.rb
@@ -5,6 +5,7 @@ module UamValidations
   MAX_ENTRY_DIGITS    = 128
   SPECIAL_CHARACTERS  = /[!"£$%{}<>|&@\/()=?^;]/
   ALLOWED_FILE_TYPES = ["application/pdf", "image/png", "image/jpeg", "image/jpg"].freeze
+  POSTCODE_REGEX = /([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})/
 
   included do
     validate :validate_is_under_18, if: -> { run_validation? :is_under_18 }
@@ -37,7 +38,11 @@ module UamValidations
     validate :validate_residential_postcode, if: -> { run_validation? :sponsor_address_postcode }
     validate :validate_sponsor_date_of_birth, if: -> { run_validation? :sponsor_date_of_birth }
     validate :validate_minor_date_of_birth, if: -> { run_validation? :minor_date_of_birth }
-    # validate :validate_adult_date_of_birth, if: -> { run_validation? :adult_date_of_birth }
+
+    validate :validate_sponsor_address_line_1, if: -> { run_validation? :sponsor_address_line_1 }
+    validate :validate_sponsor_address_line_2, if: -> { run_validation? :sponsor_address_line_2 }
+    validate :validate_sponsor_address_town, if: -> { run_validation? :sponsor_address_town }
+    validate :validate_sponsor_address_postcode, if: -> { run_validation? :sponsor_address_postcode }
   end
 
   def validate_sponsor_date_of_birth
@@ -234,26 +239,26 @@ module UamValidations
   end
 
   def validate_sponsor_address_line_1
-    if @sponsor_address_line_1.nil? || @sponsor_address_line_1.strip.length < MIN_ENTRY_DIGITS || @sponsor_address_line_1.strip.length > MAX_ENTRY_DIGITS
-      errors.add(:residential_line_1, I18n.t(:address_line_1, scope: :error))
+    if @different_address == "no" && (@sponsor_address_line_1.nil? || @sponsor_address_line_1.strip.length < MIN_ENTRY_DIGITS || @sponsor_address_line_1.strip.length > MAX_ENTRY_DIGITS)
+      errors.add(:sponsor_address_line_1, I18n.t(:address_line_1, scope: :error))
     end
   end
 
   def validate_sponsor_address_line_2
-    if @sponsor_address_line_2.present? && @sponsor_address_line_2.strip.length > MAX_ENTRY_DIGITS
-      errors.add(:residential_line_2, I18n.t(:address_line_2, scope: :error))
+    if @different_address == "no" && (@sponsor_address_line_2.present? && @sponsor_address_line_2.strip.length > MAX_ENTRY_DIGITS)
+      errors.add(:sponsor_address_line_2, I18n.t(:address_line_2, scope: :error))
     end
   end
 
   def validate_sponsor_address_town
-    if @sponsor_address_town.nil? || @sponsor_address_town.strip.length < MIN_ENTRY_DIGITS || @sponsor_address_town.strip.length > MAX_ENTRY_DIGITS
-      errors.add(:residential_town, I18n.t(:address_town, scope: :error))
+    if @different_address == "no" && (@sponsor_address_town.nil? || @sponsor_address_town.strip.length < MIN_ENTRY_DIGITS || @sponsor_address_town.strip.length > MAX_ENTRY_DIGITS)
+      errors.add(:sponsor_address_town, I18n.t(:address_town, scope: :error))
     end
   end
 
   def validate_sponsor_address_postcode
-    if @sponsor_address_postcode.nil? || @sponsor_address_postcode.strip.length < MIN_ENTRY_DIGITS || @sponsor_address_postcode.strip.length > MAX_ENTRY_DIGITS || !@sponsor_address_postcode.match(POSTCODE_REGEX)
-      errors.add(:residential_postcode, I18n.t(:address_postcode, scope: :error))
+    if @different_address == "no" && (@sponsor_address_postcode.nil? || @sponsor_address_postcode.strip.length < MIN_ENTRY_DIGITS || @sponsor_address_postcode.strip.length > MAX_ENTRY_DIGITS || !@sponsor_address_postcode.match(POSTCODE_REGEX))
+      errors.add(:sponsor_address_postcode, I18n.t(:address_postcode, scope: :error))
     end
   end
 

--- a/spec/controllers/unaccompanied_controller_spec.rb
+++ b/spec/controllers/unaccompanied_controller_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe UnaccompaniedController, type: :controller do
     uam.residential_town = "Address town"
     uam.residential_postcode = "BS2 0AX"
     uam.other_adults_address = "no"
-    uam.different_address = "no"
+    # DANGER: uam.different_address actually means the user answered "yes" when asked
+    # "Will you (the sponsor) be living at this address?"
+    uam.different_address = "yes"
 
     uam.identification_type = "passport"
     uam.identification_number = "ABC123"

--- a/spec/models/concerns/uam_validations_spec.rb
+++ b/spec/models/concerns/uam_validations_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe UamValidations, type: :model do
         uam.sponsor_address_line_1 = line
 
         expect(uam.valid?).to be(false)
-        expect(uam.errors).to include(:sponsor_address_line_1)
+        expect(uam.errors).to include(:sponsor_address_line_1), "Failed value:#{line}"
       end
     end
 
@@ -22,7 +22,7 @@ RSpec.describe UamValidations, type: :model do
         uam.sponsor_address_town = line
 
         expect(uam.valid?).to be(false)
-        expect(uam.errors).to include(:sponsor_address_town)
+        expect(uam.errors).to include(:sponsor_address_town), "Failed value:#{line}"
       end
     end
 
@@ -34,7 +34,19 @@ RSpec.describe UamValidations, type: :model do
         uam.sponsor_address_postcode = line
 
         expect(uam.valid?).to be(false)
-        expect(uam.errors).to include(:sponsor_address_postcode)
+        expect(uam.errors).to include(:sponsor_address_postcode), "Failed value:#{line}"
+      end
+    end
+
+    it "raises an error message when postcode is invalid" do
+      invalid_postcodes = ["W1", "HEllo World", "blah"]
+
+      invalid_postcodes.each do |postcode|
+        uam = new_uam
+        uam.sponsor_address_postcode = postcode
+
+        expect(uam.valid?).to be(false)
+        expect(uam.errors).to include(:sponsor_address_postcode), "Failed value:#{postcode}"
       end
     end
 

--- a/spec/models/concerns/uam_validations_spec.rb
+++ b/spec/models/concerns/uam_validations_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe UamValidations, type: :model do
       end
     end
 
+    it "raises an error message when postcode is nil or empty" do
+      empty_lines = [nil, "", " "]
+
+      empty_lines.each do |line|
+        uam = new_uam
+        uam.sponsor_address_postcode = line
+
+        expect(uam.valid?).to be(false)
+        expect(uam.errors[:sponsor_address_postcode]).to include("You must enter a valid UK postcode")
+      end
+    end
+
     def new_uam
       uam = UnaccompaniedMinor.new
       # DANGER: uam.different_address actually means the user answered "yes" or "no" when asked

--- a/spec/models/concerns/uam_validations_spec.rb
+++ b/spec/models/concerns/uam_validations_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe UamValidations, type: :model do
       end
     end
 
+    it "does not raise an error message when address line 2 is nil or empty" do
+      empty_lines = [nil, "", " "]
+
+      empty_lines.each do |line|
+        uam = new_uam
+        uam.sponsor_address_line_2 = line
+
+        expect(uam.valid?).to be(false)
+        expect(uam.errors[:sponsor_address_line_2]).not_to include("You must enter less than 128 characters")
+      end
+    end
+
     def new_uam
       uam = UnaccompaniedMinor.new
       # DANGER: uam.different_address actually means the user answered "yes" or "no" when asked

--- a/spec/models/concerns/uam_validations_spec.rb
+++ b/spec/models/concerns/uam_validations_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe UamValidations, type: :model do
       end
     end
 
+    it "raises an error message when address town is nil or empty" do
+      empty_lines = [nil, "", " "]
+
+      empty_lines.each do |line|
+        uam = new_uam
+        uam.sponsor_address_town = line
+
+        expect(uam.valid?).to be(false)
+        expect(uam.errors[:sponsor_address_town]).to include("You must enter a town or city")
+      end
+    end
+
     def new_uam
       uam = UnaccompaniedMinor.new
       # DANGER: uam.different_address actually means the user answered "yes" or "no" when asked

--- a/spec/models/concerns/uam_validations_spec.rb
+++ b/spec/models/concerns/uam_validations_spec.rb
@@ -2,11 +2,28 @@ require "rails_helper"
 
 RSpec.describe UamValidations, type: :model do
   describe "sponsor residential address validations" do
-    it "address line 1 is not valid when nil or empty" do
-      uam = UnaccompaniedMinor.new
+    it "raises an error message when address line 1 is nil or empty" do
+      empty_lines = [nil, "", " "]
 
+      empty_lines.each do |line|
+        uam = new_uam
+        uam.sponsor_address_line_1 = line
+
+        expect(uam.valid?).to be(false)
+        expect(uam.errors[:sponsor_address_line_1]).to include("You must enter an address")
+      end
+    end
+
+    def new_uam
+      uam = UnaccompaniedMinor.new
+      # DANGER: uam.different_address actually means the user answered "yes" or "no" when asked
+      # "Will you (the sponsor) be living at this address?"
+      #
+      # Setting this to "no" makes the validators run on the address fields
+      uam.different_address = "no"
+
+      # Set dummy attributes to satisfy other validators 😒
       uam.final_submission = true
-      ### mmmmm, maybe should test via the controller?
       uam.uk_parental_consent_file_size = 1
       uam.ukraine_parental_consent_file_size = 1
       uam.sponsor_date_of_birth = {
@@ -20,19 +37,7 @@ RSpec.describe UamValidations, type: :model do
         1 => Time.zone.now.year - 5,
       }
 
-      uam.different_address = "no"
-
-      uam.sponsor_address_line_1 = nil
-      expect(uam.valid?).to be(false)
-      expect(uam.errors[:sponsor_address_line_1]).to include("You must enter an address")
-
-      uam.sponsor_address_line_1 = ""
-      expect(uam.valid?).to be(false)
-      expect(uam.errors[:sponsor_address_line_1]).to include("You must enter an address")
-
-      uam.sponsor_address_line_1 = " "
-      expect(uam.valid?).to be(false)
-      expect(uam.errors[:sponsor_address_line_1]).to include("You must enter an address")
+      uam
     end
   end
 end

--- a/spec/models/concerns/uam_validations_spec.rb
+++ b/spec/models/concerns/uam_validations_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe UamValidations, type: :model do
   describe "sponsor residential address validations" do
-    it "raises an error message when address line 1 is nil or empty" do
-      empty_lines = [nil, "", " "]
+    let(:empty_lines) { [nil, "", " "].freeze }
 
+    it "raises an error message when address line 1 is nil or empty" do
       empty_lines.each do |line|
         uam = new_uam
         uam.sponsor_address_line_1 = line
@@ -15,8 +15,6 @@ RSpec.describe UamValidations, type: :model do
     end
 
     it "raises an error message when address town is nil or empty" do
-      empty_lines = [nil, "", " "]
-
       empty_lines.each do |line|
         uam = new_uam
         uam.sponsor_address_town = line
@@ -27,8 +25,6 @@ RSpec.describe UamValidations, type: :model do
     end
 
     it "raises an error message when postcode is nil or empty" do
-      empty_lines = [nil, "", " "]
-
       empty_lines.each do |line|
         uam = new_uam
         uam.sponsor_address_postcode = line
@@ -39,7 +35,7 @@ RSpec.describe UamValidations, type: :model do
     end
 
     it "raises an error message when postcode is invalid" do
-      invalid_postcodes = ["W1", "HEllo World", "blah"]
+      invalid_postcodes = ["W1", "HEllo World", "blah"].freeze
 
       invalid_postcodes.each do |postcode|
         uam = new_uam
@@ -51,8 +47,6 @@ RSpec.describe UamValidations, type: :model do
     end
 
     it "does not raise an error message when address line 2 is nil or empty" do
-      empty_lines = [nil, "", " "]
-
       empty_lines.each do |line|
         uam = new_uam
         uam.sponsor_address_line_2 = line

--- a/spec/models/concerns/uam_validations_spec.rb
+++ b/spec/models/concerns/uam_validations_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe UamValidations, type: :model do
+  describe "sponsor residential address validations" do
+    it "address line 1 is not valid when nil or empty" do
+      uam = UnaccompaniedMinor.new
+
+      uam.final_submission = true
+      ### mmmmm, maybe should test via the controller?
+      uam.uk_parental_consent_file_size = 1
+      uam.ukraine_parental_consent_file_size = 1
+      uam.sponsor_date_of_birth = {
+        3 => 1,
+        2 => 6,
+        1 => Time.zone.now.year - 36,
+      }
+      uam.minor_date_of_birth = {
+        3 => 1,
+        2 => 6,
+        1 => Time.zone.now.year - 5,
+      }
+
+      uam.different_address = "no"
+
+      uam.sponsor_address_line_1 = nil
+      expect(uam.valid?).to be(false)
+      expect(uam.errors[:sponsor_address_line_1]).to include("You must enter an address")
+
+      uam.sponsor_address_line_1 = ""
+      expect(uam.valid?).to be(false)
+      expect(uam.errors[:sponsor_address_line_1]).to include("You must enter an address")
+
+      uam.sponsor_address_line_1 = " "
+      expect(uam.valid?).to be(false)
+      expect(uam.errors[:sponsor_address_line_1]).to include("You must enter an address")
+    end
+  end
+end

--- a/spec/models/concerns/uam_validations_spec.rb
+++ b/spec/models/concerns/uam_validations_spec.rb
@@ -45,9 +45,24 @@ RSpec.describe UamValidations, type: :model do
         uam = new_uam
         uam.sponsor_address_line_2 = line
 
+        # Will not be valid because other validations currently fail.
         expect(uam.valid?).to be(false)
-        expect(uam.errors[:sponsor_address_line_2]).not_to include("You must enter less than 128 characters")
+
+        expect(uam.errors).not_to include(:sponsor_address_line_2)
       end
+    end
+
+    it "does not raise an error message when mandatory fields are complete" do
+      uam = new_uam
+      uam.sponsor_address_line_1 = "1 Some Street"
+      uam.sponsor_address_town = "Town"
+      uam.sponsor_address_postcode = "ST1 1LX"
+
+      # Will not be valid because other validations currently fail.
+      expect(uam.valid?).to be(false)
+      expect(uam.errors).not_to include(:sponsor_address_line_1)
+      expect(uam.errors).not_to include(:sponsor_address_town)
+      expect(uam.errors).not_to include(:sponsor_address_postcode)
     end
 
     def new_uam

--- a/spec/models/concerns/uam_validations_spec.rb
+++ b/spec/models/concerns/uam_validations_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe UamValidations, type: :model do
         uam.sponsor_address_line_1 = line
 
         expect(uam.valid?).to be(false)
-        expect(uam.errors[:sponsor_address_line_1]).to include("You must enter an address")
+        expect(uam.errors).to include(:sponsor_address_line_1)
       end
     end
 
@@ -22,7 +22,7 @@ RSpec.describe UamValidations, type: :model do
         uam.sponsor_address_town = line
 
         expect(uam.valid?).to be(false)
-        expect(uam.errors[:sponsor_address_town]).to include("You must enter a town or city")
+        expect(uam.errors).to include(:sponsor_address_town)
       end
     end
 
@@ -34,7 +34,7 @@ RSpec.describe UamValidations, type: :model do
         uam.sponsor_address_postcode = line
 
         expect(uam.valid?).to be(false)
-        expect(uam.errors[:sponsor_address_postcode]).to include("You must enter a valid UK postcode")
+        expect(uam.errors).to include(:sponsor_address_postcode)
       end
     end
 

--- a/spec/system/unaccompanied_minor_spec.rb
+++ b/spec/system/unaccompanied_minor_spec.rb
@@ -485,7 +485,7 @@ RSpec.describe "Unaccompanied minor expression of interest", type: :system do
       expect(page).to have_content("Enter the address where you will be living in the UK")
 
       fill_in("Address line 1", with: "Sponsor address line 1")
-      fill_in("Address line 1", with: "Sponsor address line 2")
+      fill_in("Address line 2 (optional)", with: "Sponsor address line 2")
       fill_in("Town", with: "Sponsor address town")
       fill_in("Postcode", with: "XX1 1XX")
 


### PR DESCRIPTION
[JIRA# 839](https://digital.dclg.gov.uk/jira/browse/UKRSS-839)

- Validates other sponsor residential address and blocks entry with invalid values.
- Highlights fields as required

![sponsors-adress-fail](https://user-images.githubusercontent.com/1417516/185104627-a4905c3c-bb9a-4db1-af6c-55f9180cd2a8.png)