### PR TITLE
878 - Fix name validation

### DIFF
--- a/app/controllers/unaccompanied_controller.rb
+++ b/app/controllers/unaccompanied_controller.rb
@@ -2,6 +2,7 @@ require "securerandom"
 
 class UnaccompaniedController < ApplicationController
   include ApplicationHelper
+  include CommonValidations
 
   before_action :check_last_activity, only: %i[handle_step display]
 
@@ -176,19 +177,17 @@ class UnaccompaniedController < ApplicationController
       param_other_given_name = params["unaccompanied_minor"]["other_given_name"]
       param_other_family_name = params["unaccompanied_minor"]["other_family_name"]
 
-      if param_other_given_name.blank? || param_other_family_name.blank?
-        if param_other_given_name.blank?
-          @application.errors.add(:other_given_name, I18n.t(:invalid_given_name, scope: :error))
-        else
-          @previously_entered_other_given_name = param_other_given_name
-        end
+      unless is_valid_name?(param_other_given_name)
+        @application.errors.add(:other_given_name, I18n.t(:invalid_given_name, scope: :error))
+      end
 
-        if param_other_family_name.blank?
-          @application.errors.add(:other_family_name, I18n.t(:invalid_family_name, scope: :error))
-        else
-          @previously_entered_other_family_name = param_other_family_name
-        end
+      unless is_valid_name?(param_other_family_name)
+        @application.errors.add(:other_family_name, I18n.t(:invalid_family_name, scope: :error))
+      end
 
+      unless @application.errors.empty?
+        @previously_entered_other_given_name = param_other_given_name
+        @previously_entered_other_family_name = param_other_family_name
         render_current_step
         return
       end

--- a/app/models/concerns/additional_info_validations.rb
+++ b/app/models/concerns/additional_info_validations.rb
@@ -3,7 +3,6 @@ module AdditionalInfoValidations
 
   MIN_ENTRY_DIGITS    = 3
   MAX_ENTRY_DIGITS    = 128
-  SPECIAL_CHARACTERS  = /[!"£$%{}<>|&@\/()=?^;]/
   POSTCODE_REGEX      = /([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})/
 
   included do

--- a/app/models/concerns/common_validations.rb
+++ b/app/models/concerns/common_validations.rb
@@ -48,13 +48,8 @@ module CommonValidations
   end
 
   def is_valid_name?(value)
-    if value.nil? ||
-        value.match(SPECIAL_CHARACTERS) ||
-        value.strip.length < MIN_ENTRY_DIGITS ||
-        value.strip.length > MAX_ENTRY_DIGITS
-      return false
-    end
+    validator = /^[-'a-zA-Z\s]{1,128}$/
 
-    true
+    value.present? && !!(value =~ validator)
   end
 end

--- a/app/models/concerns/common_validations.rb
+++ b/app/models/concerns/common_validations.rb
@@ -48,7 +48,9 @@ module CommonValidations
   end
 
   def is_valid_name?(value)
-    validator = /^[-'a-zA-Z\s]{1,128}$/
+    min_name_length = 1
+    max_name_length = 128
+    validator = /^[-'a-zA-Z\s]{#{min_name_length},#{max_name_length}}$/
 
     value.present? && !!(value =~ validator)
   end

--- a/app/models/concerns/common_validations.rb
+++ b/app/models/concerns/common_validations.rb
@@ -3,7 +3,6 @@ module CommonValidations
 
   MIN_ENTRY_DIGITS    = 3
   MAX_ENTRY_DIGITS    = 128
-  SPECIAL_CHARACTERS  = /[!"£$%{}<>|&@\/()=?^;]/
 
   def validate_number_adults
     @is_residential_property    = different_address.present? && different_address.casecmp("NO").zero?

--- a/app/models/concerns/common_validations.rb
+++ b/app/models/concerns/common_validations.rb
@@ -1,9 +1,6 @@
 module CommonValidations
   extend ActiveSupport::Concern
 
-  MIN_ENTRY_DIGITS    = 3
-  MAX_ENTRY_DIGITS    = 128
-
   def validate_number_adults
     @is_residential_property    = different_address.present? && different_address.casecmp("NO").zero?
     @is_number_adults_integer   = is_integer?(@number_adults)

--- a/app/models/concerns/common_validations.rb
+++ b/app/models/concerns/common_validations.rb
@@ -1,6 +1,10 @@
 module CommonValidations
   extend ActiveSupport::Concern
 
+  MIN_ENTRY_DIGITS    = 3
+  MAX_ENTRY_DIGITS    = 128
+  SPECIAL_CHARACTERS  = /[!"£$%{}<>|&@\/()=?^;]/
+
   def validate_number_adults
     @is_residential_property    = different_address.present? && different_address.casecmp("NO").zero?
     @is_number_adults_integer   = is_integer?(@number_adults)
@@ -41,5 +45,16 @@ module CommonValidations
     unless value && enum.include?(value.to_sym)
       errors.add(attribute, I18n.t(:choose_option, scope: :error))
     end
+  end
+
+  def is_valid_name?(value)
+    if value.nil? ||
+        value.match(SPECIAL_CHARACTERS) ||
+        value.strip.length < MIN_ENTRY_DIGITS ||
+        value.strip.length > MAX_ENTRY_DIGITS
+      return false
+    end
+
+    true
   end
 end

--- a/app/models/concerns/contact_details_validations.rb
+++ b/app/models/concerns/contact_details_validations.rb
@@ -3,7 +3,6 @@ module ContactDetailsValidations
 
   MIN_ENTRY_DIGITS    = 3
   MAX_ENTRY_DIGITS    = 128
-  SPECIAL_CHARACTERS  = /[!"£$%{}<>|&@\/()=?^;]/
   POSTCODE_REGEX      = /([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})/
 
   included do

--- a/app/models/concerns/uam_validations.rb
+++ b/app/models/concerns/uam_validations.rb
@@ -1,6 +1,8 @@
 module UamValidations
   extend ActiveSupport::Concern
 
+  include CommonValidations
+
   MIN_ENTRY_DIGITS    = 3
   MAX_ENTRY_DIGITS    = 128
   SPECIAL_CHARACTERS  = /[!"£$%{}<>|&@\/()=?^;]/
@@ -177,13 +179,13 @@ module UamValidations
   end
 
   def validate_given_name
-    if @given_name.nil? || @given_name.strip.length < MIN_ENTRY_DIGITS || @given_name.strip.length > MAX_ENTRY_DIGITS || @given_name.match(SPECIAL_CHARACTERS)
+    unless is_valid_name?(@given_name)
       errors.add(:given_name, I18n.t(:invalid_given_name, scope: :error))
     end
   end
 
   def validate_family_name
-    if @family_name.nil? || @family_name.strip.length < MIN_ENTRY_DIGITS || @family_name.strip.length > MAX_ENTRY_DIGITS || @family_name.match(SPECIAL_CHARACTERS)
+    unless is_valid_name?(@family_name)
       errors.add(:family_name, I18n.t(:invalid_family_name, scope: :error))
     end
   end
@@ -195,13 +197,13 @@ module UamValidations
   end
 
   def validate_minor_given_name
-    if @minor_given_name.nil? || @minor_given_name.strip.length < MIN_ENTRY_DIGITS || @minor_given_name.strip.length > MAX_ENTRY_DIGITS || @minor_given_name.match(SPECIAL_CHARACTERS)
+    unless is_valid_name?(@minor_given_name)
       errors.add(:minor_given_name, I18n.t(:invalid_given_name, scope: :error))
     end
   end
 
   def validate_minor_family_name
-    if @minor_family_name.nil? || @minor_family_name.strip.length < MIN_ENTRY_DIGITS || @minor_family_name.strip.length > MAX_ENTRY_DIGITS || @minor_family_name.match(SPECIAL_CHARACTERS)
+    unless is_valid_name?(@minor_family_name)
       errors.add(:minor_family_name, I18n.t(:invalid_family_name, scope: :error))
     end
   end
@@ -215,13 +217,13 @@ module UamValidations
   end
 
   def validate_adult_given_name
-    if @adult_given_name.nil? || @adult_given_name.strip.length < MIN_ENTRY_DIGITS || @adult_given_name.strip.length > MAX_ENTRY_DIGITS || @adult_given_name.match(SPECIAL_CHARACTERS)
+    unless is_valid_name?(@adult_given_name)
       errors.add(:adult_given_name, I18n.t(:invalid_given_name, scope: :error))
     end
   end
 
   def validate_adult_family_name
-    if @adult_family_name.nil? || @adult_family_name.strip.length < MIN_ENTRY_DIGITS || @adult_family_name.strip.length > MAX_ENTRY_DIGITS || @adult_family_name.match(SPECIAL_CHARACTERS)
+    unless is_valid_name?(@adult_family_name)
       errors.add(:adult_family_name, I18n.t(:invalid_family_name, scope: :error))
     end
   end

--- a/app/models/concerns/uam_validations.rb
+++ b/app/models/concerns/uam_validations.rb
@@ -5,7 +5,6 @@ module UamValidations
 
   MIN_ENTRY_DIGITS    = 3
   MAX_ENTRY_DIGITS    = 128
-  SPECIAL_CHARACTERS  = /[!"£$%{}<>|&@\/()=?^;]/
   ALLOWED_FILE_TYPES = ["application/pdf", "image/png", "image/jpeg", "image/jpg"].freeze
   POSTCODE_REGEX = /([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})/
 

--- a/app/views/sponsor-a-child/steps/12.html.erb
+++ b/app/views/sponsor-a-child/steps/12.html.erb
@@ -5,7 +5,7 @@
 
     <%= form_for @application, url: "/sponsor-a-child/steps/12", method: :post do |f| %>
 
-     <%= f.govuk_error_summary link_base_errors_to: :given_name %>
+     <%= f.govuk_error_summary link_base_errors_to: :other_given_name %>
 
     <h1 class="govuk-heading-l"><%= t('other_fullname.full', scope: "unaccompanied_minor.questions")%></h1>
 

--- a/spec/models/concerns/common_validations_spec.rb
+++ b/spec/models/concerns/common_validations_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe CommonValidations, type: :helper do
+  describe "name validation" do
+    it "returns false when name is not valid" do
+      invalid_names = [nil, "", " ", "!", "$", "£", "A" * 129].freeze
+
+      invalid_names.each do |name|
+        expect(is_valid_name?(name)).to be(false), "Failed value:#{name.inspect}"
+      end
+    end
+
+    it "returns true when name is valid" do
+      valid_names = ["a", "AB", "apos'ok", "Spaces OK", "Hypens-OK"].freeze
+
+      valid_names.each do |name|
+        expect(is_valid_name?(name)).to be(true), "Failed value:#{name.inspect}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Jira 878](https://digital.dclg.gov.uk/jira/browse/UKRSS-878)

Given name and family name validations were:
- Permitting '+' and '~' chars
- Not consistently applied across all names

This PR creates a single reusable validator and points all names to the validator.

- Min length of 1 char
- Permit space, hyphen and apos
- No special chars