### PR TITLE
Delete tech-debt to swerve validators incorrectly running on submit 👊🏻 

### DIFF
--- a/app/controllers/unaccompanied_controller.rb
+++ b/app/controllers/unaccompanied_controller.rb
@@ -442,23 +442,8 @@ class UnaccompaniedController < ApplicationController
     @application.final_submission = true
 
     Rails.logger.debug "Submit JSON: #{@application.as_json}"
-    isvalid = @application.valid?
 
-    unless isvalid
-      if @application.errors.include?(:adult_given_name)
-        @application.errors.delete(:adult_given_name)
-      end
-      if @application.errors.include?(:adult_family_name)
-        @application.errors.delete(:adult_family_name)
-      end
-      if @application.errors.include?(:adult_date_of_birth)
-        @application.errors.delete(:adult_date_of_birth)
-      end
-
-      isvalid = @application.errors.empty?
-    end
-
-    if isvalid
+    if @application.valid?
       @application.save!(validate: false)
       session[:app_reference] = @application.reference
       session[:unaccompanied_minor] = {}

--- a/app/models/concerns/uam_validations.rb
+++ b/app/models/concerns/uam_validations.rb
@@ -216,13 +216,13 @@ module UamValidations
   end
 
   def validate_adult_given_name
-    unless is_valid_name?(@adult_given_name)
+    if !@final_submission && !is_valid_name?(@adult_given_name)
       errors.add(:adult_given_name, I18n.t(:invalid_given_name, scope: :error))
     end
   end
 
   def validate_adult_family_name
-    unless is_valid_name?(@adult_family_name)
+    if !@final_submission && !is_valid_name?(@adult_family_name)
       errors.add(:adult_family_name, I18n.t(:invalid_family_name, scope: :error))
     end
   end

--- a/spec/controllers/unaccompanied_controller_spec.rb
+++ b/spec/controllers/unaccompanied_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe UnaccompaniedController, type: :controller do
       allow(SendUnaccompaniedMinorJob).to receive(:perform_later)
     end
 
-    it "strips uneeded errors and submits. Lord forgive us" do
+    it "queues the json to be sent and sends the user to the confirmation page" do
       post :submit
 
       expect(uam.errors.empty?).to be(true)


### PR DESCRIPTION
To hit a release deadline we were deleting validation errors on final submission.

Time to pay that debt down and scratch that dirty itch 💪🏻
 
The errors were for fields:
-  That are not submitted in the json
-  Used as "proxy" data placeholders, in the views (see [27.html.erb](app/views/sponsor-a-child/steps/27.html.erb)) for other the "others adults" data.
- Unwinding it completely is likely too much at this point in time 

This PR simply disables the relevant validators.

Now I feel better!