### PR TITLE
Converts selecting an application to resume from GET to POST

### DIFF
--- a/app/controllers/token_based_resume_controller.rb
+++ b/app/controllers/token_based_resume_controller.rb
@@ -114,12 +114,11 @@ class TokenBasedResumeController < ApplicationController
   end
 
   def select_multiple_applications
-    selected_application = request.query_parameters["ref"]
-    if selected_application
+    if request.post?
+      selected_application = request.POST["reference"]
       @application = UnaccompaniedMinor.find_by(reference: selected_application)
       session[:app_reference] = selected_application
       session[:unaccompanied_minor] = @application.as_json
-
       render "sponsor-a-child/task_list"
     else
       flash[:error] = "No applications found"

--- a/app/views/token-based-resume/select_multiple_applications.erb
+++ b/app/views/token-based-resume/select_multiple_applications.erb
@@ -20,7 +20,13 @@
                         <% if application.is_submitted? || application.is_cancelled? %>
                             <%= application.reference %>
                         <% else %>
-                            <a href="/sponsor-a-child/resume-application/select?ref=<%= application.reference %>"><%= application.reference %></a>
+                            <form action="/sponsor-a-child/resume-application/select" method="post" class="govuk-!-text-align-left">
+                                <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>" />
+                                <input type="hidden" name="reference" value="<%= application.reference %>" />
+                                <a href="" onclick="this.closest('form').submit();return false;" class="govuk-link">
+                                    <%= application.reference %>
+                                </a>
+                            </form>
                         <% end %>
                     </td>
                     <td class="govuk-table__cell govuk-table__cell--numeric"><%= application.updated_at.in_time_zone("London").strftime("%d-%m-%Y at %I:%M%p") %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
   get "/sponsor-a-child/resume-application", to: "token_based_resume#display"
   post "/sponsor-a-child/resume-application", to: "token_based_resume#submit"
   get "/sponsor-a-child/resume-application/select", to: "token_based_resume#select_multiple_applications"
+  post "/sponsor-a-child/resume-application/select", to: "token_based_resume#select_multiple_applications"
   get "/sponsor-a-child/session-expired", to: "token_based_resume#session_expired"
   get "/sponsor-a-child/save-and-return/confirm", to: "token_based_resume#save_return_confirm"
   get "/sponsor-a-child/save-and-return/resend-link", to: "token_based_resume#save_return_resend_link_form"

--- a/spec/controllers/token_based_resume_controller_spec.rb
+++ b/spec/controllers/token_based_resume_controller_spec.rb
@@ -71,9 +71,9 @@ RSpec.describe TokenBasedResumeController, type: :controller do
     it "loads a single application given matching token" do
       UnaccompaniedMinor.where.not(reference: uam.reference).destroy_all
 
-      parms = { abstract_resume_token: { token: sms_code }, uuid: magic_id }
+      params = { abstract_resume_token: { token: sms_code }, uuid: magic_id }
 
-      post :submit, params: parms
+      post :submit, params: params
 
       expect(response.status).to eq(200)
       expect(response).to render_template("sponsor-a-child/task_list")
@@ -101,9 +101,9 @@ RSpec.describe TokenBasedResumeController, type: :controller do
       )
       uam2.save!
 
-      parms = { abstract_resume_token: { token: sms_code }, uuid: magic_id }
+      params = { abstract_resume_token: { token: sms_code }, uuid: magic_id }
 
-      post :submit, params: parms
+      post :submit, params: params
 
       expect(response.status).to eq(200)
       expect(response).to render_template("token-based-resume/select_multiple_applications")
@@ -118,8 +118,8 @@ RSpec.describe TokenBasedResumeController, type: :controller do
     end
 
     it "shows the task list after an application has been selected" do
-      parms = { reference: uam.reference }
-      post :select_multiple_applications, params: parms
+      params = { reference: uam.reference }
+      post :select_multiple_applications, params: params
 
       expect(response.status).to eq(200)
       expect(response).to render_template("sponsor-a-child/task_list")
@@ -129,9 +129,9 @@ RSpec.describe TokenBasedResumeController, type: :controller do
   describe "User errors" do
     it "gets error when sms code is not entered" do
       magic_id = "e5c4fe58-a8ca-4e6f-aaa6-7e0a381eb3dc".freeze
-      parms = { abstract_resume_token: { token: "" }, uuid: magic_id }
+      params = { abstract_resume_token: { token: "" }, uuid: magic_id }
 
-      post :submit, params: parms
+      post :submit, params: params
 
       expect(response.status).to eq(200)
       expect(response).to render_template("token-based-resume/session_resume_form")
@@ -141,9 +141,9 @@ RSpec.describe TokenBasedResumeController, type: :controller do
     it "shows an error when sms code is not numeric" do
       magic_id = "e5c4fe58-a8ca-4e6f-aaa6-7e0a381eb3dc".freeze
       non_numeric_code = "ABCDEF".freeze
-      parms = { abstract_resume_token: { token: non_numeric_code }, uuid: magic_id }
+      params = { abstract_resume_token: { token: non_numeric_code }, uuid: magic_id }
 
-      post :submit, params: parms
+      post :submit, params: params
 
       expect(response.status).to eq(200)
       expect(response).to render_template("token-based-resume/session_resume_form")
@@ -153,9 +153,9 @@ RSpec.describe TokenBasedResumeController, type: :controller do
     it "shows an error when sms code is entered but no application exists for the code" do
       magic_id = "e5c4fe58-a8ca-4e6f-aaa6-7e0a391eb3dc".freeze
       non_numeric_code = "665312".freeze
-      parms = { abstract_resume_token: { token: non_numeric_code }, uuid: magic_id }
+      params = { abstract_resume_token: { token: non_numeric_code }, uuid: magic_id }
 
-      post :submit, params: parms
+      post :submit, params: params
 
       expect(response.status).to eq(302)
       expect(response).to redirect_to("/sponsor-a-child/resume-application?uuid=#{magic_id}")
@@ -185,9 +185,9 @@ RSpec.describe TokenBasedResumeController, type: :controller do
     it "shows an error when sms code is timed out" do
       magic_id = "e5c4fe58-a8ca-4e6f-aaa6-7e0a381eb3dc".freeze
       numeric_code = 123_456
-      parms = { abstract_resume_token: { token: numeric_code }, uuid: magic_id }
+      params = { abstract_resume_token: { token: numeric_code }, uuid: magic_id }
 
-      post :submit, params: parms
+      post :submit, params: params
 
       expect(response.status).to eq(302)
       expect(response).to redirect_to("/sponsor-a-child/resume-application?uuid=#{magic_id}")

--- a/spec/controllers/token_based_resume_controller_spec.rb
+++ b/spec/controllers/token_based_resume_controller_spec.rb
@@ -116,6 +116,14 @@ RSpec.describe TokenBasedResumeController, type: :controller do
       expect(response).to render_template("token-based-resume/select_multiple_applications")
       expect(flash[:error]).to eq("No applications found")
     end
+
+    it "shows the task list after an application has been selected" do
+      parms = { reference: uam.reference }
+      post :select_multiple_applications, params: parms
+
+      expect(response.status).to eq(200)
+      expect(response).to render_template("sponsor-a-child/task_list")
+    end
   end
 
   describe "User errors" do


### PR DESCRIPTION
This is just to avoid exposing the `reference` of an application in the url bar, plus it's csrf-protected

![Screenshot 2022-08-26 at 11 45 41 am](https://user-images.githubusercontent.com/1381563/186887465-2b5ff865-f2c0-40f7-be5d-c48854243aeb.png)

