### PR TITLE
Render empty 404 for (googlebot) requests that are not html.

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -6,7 +6,10 @@ class ErrorsController < ApplicationController
   end
 
   def not_found
-    render status: :not_found
+    respond_to do |format|
+      format.html { render status: :not_found }
+      format.any  { head :not_found, "content_type" => "text/plain" }
+    end
   end
 
   def internal_server_error


### PR DESCRIPTION
Our top error is not gracefully handling 404's that come from googlebot.

This will simply return an empty "text/plain" and empty 404 and reduce template not found errors.

See [here](https://www.dxw.com/2014/05/rendering-nothing-on-404-in-a-ruby-on-rails-api/) for the reasoning.

