### PR TITLE
Trap and ignore expected gov notify errors in no prod

### DIFF
--- a/app/mailers/gov_notify_mailer.rb
+++ b/app/mailers/gov_notify_mailer.rb
@@ -4,7 +4,7 @@ class GovNotifyMailer < GovukNotifyRails::Mailer
 
     set_personalisation(fullname: application.fullname, reference: application.reference)
 
-    mail(to: application.email)
+    send_to(application.email)
   end
 
   def send_organisation_confirmation_email(application)
@@ -12,7 +12,7 @@ class GovNotifyMailer < GovukNotifyRails::Mailer
 
     set_personalisation(fullname: application.fullname, reference: application.reference)
 
-    mail(to: application.email)
+    send_to(application.email)
   end
 
   def send_additional_info_confirmation_email(application)
@@ -20,7 +20,7 @@ class GovNotifyMailer < GovukNotifyRails::Mailer
 
     set_personalisation(fullname: application.fullname, reference: application.reference)
 
-    mail(to: application.email)
+    send_to(application.email)
   end
 
   def send_unaccompanied_minor_confirmation_email(application)
@@ -28,7 +28,7 @@ class GovNotifyMailer < GovukNotifyRails::Mailer
 
     set_personalisation(fullname: application.sponsor_full_name?, reference: application.reference)
 
-    mail(to: application.email)
+    send_to(application.email)
   end
 
   def send_save_and_return_email(given_name, link, email)
@@ -36,6 +36,18 @@ class GovNotifyMailer < GovukNotifyRails::Mailer
 
     set_personalisation(given_name:, save_and_return_link: link)
 
-    mail(to: email)
+    send_to(email)
+  end
+
+private
+
+  def send_to(email_address)
+    mail(to: email_address)
+  rescue Notifications::Client::BadRequestError => e
+    if !Rails.env.production? && e.message.include?("Can’t send to this recipient using a team-only API key")
+      # ignore
+    else
+      raise
+    end
   end
 end


### PR DESCRIPTION
[Jira 906](https://digital.dclg.gov.uk/jira/browse/UKRSS-906)

By design gov.notify will not send emails to non team members in non prod envs and raises an exception.
This is expected behaviour that pollutes the error logs - we trap and ignore them