### PR TITLE
Stop sentry logging for health end point

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -17,7 +17,7 @@ Sentry.init do |config|
     when /request/
       # for Rails applications, transaction_name would be the request's path (env["PATH_INFO"]) instead of "Controller#action"
       case transaction_name
-      when /health_check/
+      when /health/
         0.0
       else
         0.1


### PR DESCRIPTION
The Sentry logging volume was exceeded last month.
This PR will stop logs for the health end point - we don't need to know the performance and it was the largest volume.