### PR TITLE
902 future date on child dob

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,10 +168,6 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.8-aarch64-linux)
-      racc (~> 1.4)
-    nokogiri (1.13.8-arm64-darwin)
-      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (5.3.0)
@@ -343,8 +339,6 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
-  aarch64-linux-musl
-  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,10 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.8-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.13.8-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (5.3.0)
@@ -339,6 +343,8 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  aarch64-linux-musl
+  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/unaccompanied_controller.rb
+++ b/app/controllers/unaccompanied_controller.rb
@@ -311,19 +311,14 @@ class UnaccompaniedController < ApplicationController
 
         if minor_dob < 18.years.ago.to_date
           @application.errors.add(:minor_date_of_birth, I18n.t(:too_old_date_of_birth, scope: :error))
-
-          render_current_step
-          return
-        end
-        if minor_dob > Date.current
+        elsif minor_dob > Date.current
           @application.errors.add(:minor_date_of_birth, I18n.t(:date_in_future, scope: :error))
-
-          render_current_step
-          return
         end
       rescue Date::Error
         @application.errors.add(:minor_date_of_birth, I18n.t(:invalid_date_of_birth, scope: :error))
+      end
 
+      unless @application.errors.empty?
         render_current_step
         return
       end

--- a/app/controllers/unaccompanied_controller.rb
+++ b/app/controllers/unaccompanied_controller.rb
@@ -311,7 +311,7 @@ class UnaccompaniedController < ApplicationController
 
         if minor_dob < 18.years.ago.to_date
           @application.errors.add(:minor_date_of_birth, I18n.t(:too_old_date_of_birth, scope: :error))
-  
+
           render_current_step
           return
         end

--- a/app/controllers/unaccompanied_controller.rb
+++ b/app/controllers/unaccompanied_controller.rb
@@ -238,7 +238,7 @@ class UnaccompaniedController < ApplicationController
       when "none"
         @application.identification_number = ""
       else
-        @application.errors.add(:identification_type, I18n.t(:invalid_id_type, scope: :error))
+        @application.errors.add(:identification_type, I18n.t(:choose_option, scope: :error))
 
         render_current_step
         return
@@ -311,6 +311,12 @@ class UnaccompaniedController < ApplicationController
 
         if minor_dob < 18.years.ago.to_date
           @application.errors.add(:minor_date_of_birth, I18n.t(:too_old_date_of_birth, scope: :error))
+  
+          render_current_step
+          return
+        end
+        if minor_dob > Date.current
+          @application.errors.add(:minor_date_of_birth, I18n.t(:date_in_future, scope: :error))
 
           render_current_step
           return

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -479,7 +479,7 @@ en:
     too_young_date_of_birth: You must be over 18 to sponsor a child
     no_application_found: There is no application associated with that email address
     not_over_16_years_old: They must be over 16
-    invalid_id_type: Select an identity document you have, or select ‘I don't have any of these’
+    invalid_id_type: You must select an option to continue 
     invalid_id_number: You must enter a valid identity document number
     invalid_nationality: You must select a valid nationality
     min_chars_digits: You must enter at least 6 characters (numbers or letters)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -475,11 +475,11 @@ en:
     no_file_chosen: You must choose a file
     file_too_large: Your file must be smaller than 20MB
     invalid_date_of_birth: Enter a valid date of birth
+    date_in_future: The date must not be in the future
     too_old_date_of_birth: They must be under 18 to be considered a child in the UK
     too_young_date_of_birth: You must be over 18 to sponsor a child
     no_application_found: There is no application associated with that email address
     not_over_16_years_old: They must be over 16
-    invalid_id_type: You must select an option to continue 
     invalid_id_number: You must enter a valid identity document number
     invalid_nationality: You must select a valid nationality
     min_chars_digits: You must enter at least 6 characters (numbers or letters)

--- a/spec/system/unaccompanied_minor_minors_details_spec.rb
+++ b/spec/system/unaccompanied_minor_minors_details_spec.rb
@@ -109,6 +109,23 @@ RSpec.describe "Unaccompanied minor - minors details", type: :system do
 
       expect(page).to have_content("Error: Enter a valid date of birth")
     end
+
+    fit "prompts the user to enter a valid date of birth when future date is chosen" do
+      tomorrow = Date.current.tomorrow
+
+
+      navigate_to_child_personal_details_name_entry
+      enter_name_and_continue
+      enter_email_and_continue
+
+      fill_in("Day", with: tomorrow.day)
+      fill_in("Month", with: tomorrow.month)
+      fill_in("Year", with: tomorrow.year)
+
+      click_button("Continue")
+
+      expect(page).to have_content("Error: The date must not be in the future")
+    end
   end
 
   def navigate_to_task_list

--- a/spec/system/unaccompanied_minor_minors_details_spec.rb
+++ b/spec/system/unaccompanied_minor_minors_details_spec.rb
@@ -110,9 +110,8 @@ RSpec.describe "Unaccompanied minor - minors details", type: :system do
       expect(page).to have_content("Error: Enter a valid date of birth")
     end
 
-    fit "prompts the user to enter a valid date of birth when future date is chosen" do
+    it "prompts the user to enter a valid date of birth when future date is entered" do
       tomorrow = Date.current.tomorrow
-
 
       navigate_to_child_personal_details_name_entry
       enter_name_and_continue

--- a/spec/system/unaccompanied_minor_spec.rb
+++ b/spec/system/unaccompanied_minor_spec.rb
@@ -1031,7 +1031,7 @@ RSpec.describe "Unaccompanied minor expression of interest", type: :system do
       expect(page).to have_content("Do you have any of these identity documents?")
 
       click_button("Continue")
-      expect(page).to have_content("Select an identity document you have, or select ‘I don't have any of these’")
+      expect(page).to have_content("You must select an option to continue")
     end
 
     it "when passport number is displayed when going through id question" do


### PR DESCRIPTION
[JIRA-902](https://digital.dclg.gov.uk/jira/browse/UKRSS-902)

Used to show no error on Child DoB in future. This has been fixed as shown below. 
<img width="773" alt="Screenshot 2022-08-31 at 10 41 56" src="https://user-images.githubusercontent.com/98767768/187649699-c561a4cb-1bed-4844-9496-d654c4e727c9.png">
