### PR TITLE
912 - Quick fix for check answers - child contact details

### DIFF
--- a/app/views/sponsor-a-child/check_answers.html.erb
+++ b/app/views/sponsor-a-child/check_answers.html.erb
@@ -190,12 +190,10 @@
           Contact
         </dt>
         <dd class="govuk-summary-list__value">
-          <% if @application.minor_contact_type.present? %>
-            <% if @application.minor_contact_type.casecmp("email").zero? %>
-              <%= @application.minor_email %>
-            <% elsif @application.minor_contact_type.casecmp("telephone").zero? %>
-              <%= @application.minor_phone_number %>
-            <% end %>
+          <% if @application.minor_email.present? %>
+            <%= @application.minor_email %>
+          <% elsif @application.minor_phone_number.present? %>
+            <%= @application.minor_phone_number %>
           <% else %>
             They cannot be contacted
           <% end %>


### PR DESCRIPTION
[JIRA-912](https://digital.dclg.gov.uk/jira/browse/UKRSS-912)

The child contact details "type" is now an array because multiple entries are possible.
This breaks the check answers page.

This is not tested so regressed in https://github.com/communitiesuk/ukraine-sponsor-resettlement/pull/257

Regression tests to follow!