### PR TITLE
Retain child dob

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.8-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.13.8-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (5.3.0)
@@ -342,6 +344,7 @@ GEM
 
 PLATFORMS
   aarch64-linux-musl
+  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/app/views/sponsor-a-child/steps/29.html.erb
+++ b/app/views/sponsor-a-child/steps/29.html.erb
@@ -14,16 +14,7 @@
       <%= "#{@adult["given_name"]} #{@adult["family_name"]}" %>
     </div>
 
-    <% 
-      adult = @application.adults_at_address[params["key"]]
-      if adult.present? && adult[:date_of_birth].present?
-        date_parts = adult[:date_of_birth].split('-')
 
-        @application.adult_date_of_birth[1] = date_parts[0]
-        @application.adult_date_of_birth[2] = date_parts[1]
-        @application.adult_date_of_birth[3] = date_parts[2]
-      end
-    %>
 
     <div class="govuk-hint" id="unaccompanied-minor-minor-date-of-birth-hint">For example, 31 3 2010</div>
 

--- a/spec/system/sponsor_additional_details_spec.rb
+++ b/spec/system/sponsor_additional_details_spec.rb
@@ -16,28 +16,38 @@ RSpec.describe "Sponsor additional details", type: :system do
     end
 
     it "retains date of birth when page is reloaded" do
-      visit "/sponsor-a-child/task-list"
-      click_link("Additional details")
-      expect(page).to have_content("Do you have any of these identity documents?")
+      dob = Time.zone.now - 20.years
+
+      navigate_to_additional_details
 
       choose("Passport")
       fill_in("Passport number", with: valid_document_id)
       click_button("Continue")
 
       expect(page).to have_content("Enter your date of birth")
-      fill_in("Day", with: "1")
-      fill_in("Month", with: "1")
-      fill_in("Year", with: "2000")
+
+      fill_in("Day", with: dob.day)
+      fill_in("Month", with: dob.month)
+      fill_in("Year", with: dob.year)
+
       click_button("Continue")
 
-      visit "/sponsor-a-child/task-list"
-      click_link("Additional details")
-      expect(page).to have_content("Do you have any of these identity documents?")
+      navigate_to_additional_details
+
+      passport_value = find_field("unaccompanied_minor[passport_identification_number]").value
+      expect(passport_value).to eq(valid_document_id)
+
       click_button("Continue")
 
-      expect(page).to have_field("Day", with: "1")
-      expect(page).to have_field("Month", with: "1")
-      expect(page).to have_field("Year", with: "2000")
+      expect(page).to have_field("Day", with: dob.day)
+      expect(page).to have_field("Month", with: dob.month)
+      expect(page).to have_field("Year", with: dob.year)
     end
+  end
+
+  def navigate_to_additional_details
+    visit "/sponsor-a-child/task-list"
+    click_link("Additional details")
+    expect(page).to have_content("Do you have any of these identity documents?")
   end
 end

--- a/spec/system/sponsor_additional_details_spec.rb
+++ b/spec/system/sponsor_additional_details_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+require "securerandom"
+
+RSpec.describe "Sponsor additional details", type: :system do
+  before do
+    driven_by(:rack_test_user_agent)
+  end
+
+  describe "adding sponsors additional details" do
+    let(:valid_document_id) { "SomeValidId123456".freeze }
+
+    before do
+      application = UnaccompaniedMinor.new
+      application.save!
+      page.set_rack_session(app_reference: application.reference)
+    end
+
+    it "retains date of birth when page is reloaded" do
+      visit "/sponsor-a-child/task-list"
+      click_link("Additional details")
+      expect(page).to have_content("Do you have any of these identity documents?")
+
+      choose("Passport")
+      fill_in("Passport number", with: valid_document_id)
+      click_button("Continue")
+
+      expect(page).to have_content("Enter your date of birth")
+      fill_in("Day", with: "1")
+      fill_in("Month", with: "1")
+      fill_in("Year", with: "2000")
+      click_button("Continue")
+
+      visit "/sponsor-a-child/task-list"
+      click_link("Additional details")
+      expect(page).to have_content("Do you have any of these identity documents?")
+      click_button("Continue")
+
+      expect(page).to have_field("Day", with: "1")
+      expect(page).to have_field("Month", with: "1")
+      expect(page).to have_field("Year", with: "2000")
+    end
+  end
+end

--- a/spec/system/unaccompanied_minor_other_adults_spec.rb
+++ b/spec/system/unaccompanied_minor_other_adults_spec.rb
@@ -61,15 +61,15 @@ RSpec.describe "Unaccompanied minor other adults", type: :system do
     end
 
     it "retains entered DoB on round trip" do
-      dob_year = Time.zone.now.year - 20
+      dob = Time.zone.now - 20.years
 
-      add_date_of_birth
+      add_date_of_birth(dob.day, dob.month, dob.year)
       visit "/sponsor-a-child/task-list"
       click_link("Bob Jones details")
 
-      expect(page).to have_field("Day", with: "1")
-      expect(page).to have_field("Month", with: "2")
-      expect(page).to have_field("Year", with: dob_year)
+      expect(page).to have_field("Day", with: dob.day)
+      expect(page).to have_field("Month", with: dob.month)
+      expect(page).to have_field("Year", with: dob.year)
     end
   end
 

--- a/spec/system/unaccompanied_minor_other_adults_spec.rb
+++ b/spec/system/unaccompanied_minor_other_adults_spec.rb
@@ -59,6 +59,18 @@ RSpec.describe "Unaccompanied minor other adults", type: :system do
         selected: "Denmark",
       )
     end
+
+    it "retains entered DoB on round trip" do
+      dob_year = Time.zone.now.year - 20
+
+      add_date_of_birth
+      visit "/sponsor-a-child/task-list"
+      click_link("Bob Jones details")
+
+      expect(page).to have_field("Day", with: "1")
+      expect(page).to have_field("Month", with: "2")
+      expect(page).to have_field("Year", with: dob_year)
+    end
   end
 
   def add_date_of_birth(day = 1, month = 2, year = Time.zone.now.year - 20)


### PR DESCRIPTION
[Jira-913](https://digital.dclg.gov.uk/jira/browse/UKRSS-913)

All DoBs now retain the information in their fields when pages are reloaded.