### PR TITLE
Fix start now as per GDS

### DIFF
--- a/app/views/sponsor-a-child/start.html.erb
+++ b/app/views/sponsor-a-child/start.html.erb
@@ -18,7 +18,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <div class="govuk-button-group">
-          <%= govuk_button_link_to 'Start now', "/sponsor-a-child/check" %>
+          <%= govuk_start_button(text:'Start now', href: "/sponsor-a-child/check") %>
           <% if @feature_save_and_return_active %>
             <a class="govuk-link" href="/sponsor-a-child/save-and-return/resend-link">Continue a saved application</a>
           <% end %>


### PR DESCRIPTION
Shows the caret in Start now button

Found the solution in https://govuk-components.netlify.app/components/start-button/#input-erb-start-button

Fixes https://digital.dclg.gov.uk/jira/browse/UKRSS-908

![Screenshot 2022-09-06 at 2 51 17 pm](https://user-images.githubusercontent.com/1381563/188653462-3d93dcde-a2b8-42c2-b809-66425d627b3c.png)
