### PR TITLE
933 add http basic auth security to consent upload form

### DIFF
--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -141,6 +141,8 @@ jobs:
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           BASIC_AUTH_USER: ${{ secrets.BASIC_AUTH_USER }}
           BASIC_AUTH_PASS: ${{ secrets.BASIC_AUTH_PASS }}
+          CONSENT_UPLOAD_USER: ${{ secrets.CONSENT_UPLOAD_USER }}
+          CONSENT_UPLOAD_PASS: ${{ secrets.CONSENT_UPLOAD_PASS }}
           REMOTE_API_URL: ${{ secrets.REMOTE_API_URL }}
           REMOTE_API_TOKEN: ${{ secrets.REMOTE_API_TOKEN }}
           REMOTE_API_TOKEN_UAM: ${{ secrets.REMOTE_API_TOKEN_UAM }}
@@ -167,6 +169,8 @@ jobs:
           cf set-env $APP_NAME RAILS_MASTER_KEY $RAILS_MASTER_KEY
           cf set-env $APP_NAME BASIC_AUTH_USER $BASIC_AUTH_USER
           cf set-env $APP_NAME BASIC_AUTH_PASS $BASIC_AUTH_PASS
+          cf set-env $APP_NAME CONSENT_UPLOAD_USER $CONSENT_UPLOAD_USER
+          cf set-env $APP_NAME CONSENT_UPLOAD_PASS $CONSENT_UPLOAD_PASS
           cf set-env $APP_NAME REMOTE_API_URL $REMOTE_API_URL
           cf set-env $APP_NAME REMOTE_API_TOKEN $REMOTE_API_TOKEN
           cf set-env $APP_NAME REMOTE_API_TOKEN_UAM $REMOTE_API_TOKEN_UAM
@@ -274,6 +278,8 @@ jobs:
           CF_SPACE: ${{ secrets.CF_SPACE }}
           CF_ORG: ${{ secrets.CF_ORG }}
           APP_NAME: ukraine-sponsor-resettlement-production
+          CONSENT_UPLOAD_USER: ${{ secrets.CONSENT_UPLOAD_USER }}
+          CONSENT_UPLOAD_PASS: ${{ secrets.CONSENT_UPLOAD_PASS }}
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           REMOTE_API_URL: ${{ secrets.REMOTE_API_URL }}
           REMOTE_API_TOKEN: ${{ secrets.REMOTE_API_TOKEN }}
@@ -299,6 +305,8 @@ jobs:
           cf auth
           cf target -o $CF_ORG -s $CF_SPACE
           cf set-env $APP_NAME RAILS_MASTER_KEY $RAILS_MASTER_KEY
+          cf set-env $APP_NAME CONSENT_UPLOAD_USER $CONSENT_UPLOAD_USER
+          cf set-env $APP_NAME CONSENT_UPLOAD_PASS $CONSENT_UPLOAD_PASS
           cf set-env $APP_NAME REMOTE_API_URL $REMOTE_API_URL
           cf set-env $APP_NAME REMOTE_API_TOKEN $REMOTE_API_TOKEN
           cf set-env $APP_NAME REMOTE_API_TOKEN_UAM $REMOTE_API_TOKEN_UAM

--- a/app/controllers/foundry_consent_upload_controller.rb
+++ b/app/controllers/foundry_consent_upload_controller.rb
@@ -1,15 +1,15 @@
 class FoundryConsentUploadController < ApplicationController
   add_flash_types :error
 
+  unless Rails.env.test?
+    http_basic_authenticate_with name: ENV.fetch("CONSENT_UPLOAD_USER"), password: ENV.fetch("CONSENT_UPLOAD_PASS")
+  end
+
   def display
     render "foundry_consent_upload/form"
   end
 
   def form
-    if Rails.env.production?
-      render nothing: true, status: :method_not_allowed
-    end
-
     begin
       uam = UnaccompaniedMinor.find_by_reference(params["consent"]["reference"])
       consent_uploader = TransferConsents.new


### PR DESCRIPTION
[JIRA-933](https://digital.dclg.gov.uk/jira/browse/UKRSS-933)

In **all envs except test** - secures consent uploader "admin" form behind basic auth using new env var pair.

Env vars are set and ready to go and entered into the password store.