### PR TITLE
Sort nationalities by name

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,7 +19,7 @@ module ApplicationHelper
     csv ||= CSV.parse(csv_file_path, col_sep: ",", row_sep: :auto, skip_blanks: true)
 
     nationalities ||= [OpenStruct.new(val: "---", name: "---")]
-    csv.each_with_index do |row, index|
+    csv.sort_by { |nationality| nationality[1] }.each_with_index do |row, index|
       next if index.zero? # skip headers
 
       nationalities << OpenStruct.new(val: "#{row[0]} - #{row[1]}", name: (row[1]).to_s)


### PR DESCRIPTION
Jira ticket https://digital.dclg.gov.uk/jira/browse/UKRSS-905

I found out that this was because of how the government provided list is configured

Each nationality has 2 items: country code and country name.
The country code does not correspond to the country name all the times: example, Southern French Territories has ATF as the country code.
The default ordering places it at the top with the As, rather than towards the bottom with the Ss.

I have fixed it by making it sort by country name instead