### PR TITLE
Trap 500's when application not found and redirect to start page

### DIFF
--- a/app/controllers/unaccompanied_controller.rb
+++ b/app/controllers/unaccompanied_controller.rb
@@ -62,7 +62,6 @@ class UnaccompaniedController < ApplicationController
       redirect_to "/sponsor-a-child" and return
     end
 
-    Rails.logger.debug "Step:#{step} App:#{@application.as_json}"
 
     if NATIONALITY_STEPS.include?(step)
       @nationalities = get_nationalities_as_list

--- a/app/controllers/unaccompanied_controller.rb
+++ b/app/controllers/unaccompanied_controller.rb
@@ -90,7 +90,6 @@ class UnaccompaniedController < ApplicationController
       # Set properties based on values from hash of adults
       @adult = @application.adults_at_address[params["key"]]
 
-
       adult_dob = @adult["date_of_birth"]
       adult_nationality = @adult["nationality"]
       adult_id_type_and_number = @adult["id_type_and_number"]

--- a/app/controllers/unaccompanied_controller.rb
+++ b/app/controllers/unaccompanied_controller.rb
@@ -91,7 +91,6 @@ class UnaccompaniedController < ApplicationController
       # Set properties based on values from hash of adults
       @adult = @application.adults_at_address[params["key"]]
 
-      Rails.logger.debug "Adult: #{@adult}"
 
       adult_dob = @adult["date_of_birth"]
       adult_nationality = @adult["nationality"]

--- a/app/controllers/unaccompanied_controller.rb
+++ b/app/controllers/unaccompanied_controller.rb
@@ -55,73 +55,71 @@ class UnaccompaniedController < ApplicationController
 
   def display
     @application = UnaccompaniedMinor.find_by_reference(session[:app_reference])
-
-    Rails.logger.debug "App JSON: #{@application.as_json}"
-
     step = params["stage"].to_i
-
     @feature_save_and_return_active = (ENV["UAM_FEATURE_SAVE_AND_RETURN_ACTIVE"] == "true")
 
-    if step.positive? && step <= MAX_STEPS
-      if NATIONALITY_STEPS.include?(step)
-        @nationalities = get_nationalities_as_list
-      end
-
-      if SAVE_AND_RETURN_STEPS.include?(step)
-        if request.GET["save"]
-          @save_and_return_message = true
-          @save = "?save=1"
-        else
-          @save = ""
-        end
-      end
-
-      if step == SPONSOR_ID_TYPE
-        case @application.identification_type
-        when "passport"
-          @application.passport_identification_number = @application.identification_number
-        when "national_identity_card"
-          @application.id_identification_number = @application.identification_number
-        when "refugee_travel_document"
-          @application.refugee_identification_number = @application.identification_number
-        end
-      elsif ADULT_STEPS.include?(step)
-        Rails.logger.debug "Adult page!"
-
-        # Set properties based on values from hash of adults
-        @adult = @application.adults_at_address[params["key"]]
-
-        Rails.logger.debug "Adult: #{@adult}"
-
-        adult_dob = @adult["date_of_birth"]
-        adult_nationality = @adult["nationality"]
-        adult_id_type_and_number = @adult["id_type_and_number"]
-        if adult_dob.present? && adult_dob.length.positive?
-          @application.adult_date_of_birth = {
-            3 => Date.parse(adult_dob).day,
-            2 => Date.parse(adult_dob).month,
-            1 => Date.parse(adult_dob).year,
-          }
-        end
-        @application.adult_nationality = adult_nationality if adult_nationality.present? && adult_nationality.length.positive?
-        if adult_id_type_and_number.present? && adult_id_type_and_number.length.positive?
-          id_type_and_number = adult_id_type_and_number.split(" - ")
-          @application.adult_identification_type = id_type_and_number[0].to_s
-          case id_type_and_number[0].to_s
-          when "passport"
-            @application.adult_passport_identification_number = id_type_and_number[1].to_s
-          when "national_identity_card"
-            @application.adult_id_identification_number = id_type_and_number[1].to_s
-          when "refugee_travel_document"
-            @application.adult_refugee_identification_number = id_type_and_number[1].to_s
-          end
-        end
-      end
-
-      render "sponsor-a-child/steps/#{step}"
-    else
-      redirect_to "/sponsor-a-child"
+    if @application.nil? || (1..MAX_STEPS).exclude?(step)
+      redirect_to "/sponsor-a-child" and return
     end
+
+    Rails.logger.debug "Step:#{step} App:#{@application.as_json}"
+
+    if NATIONALITY_STEPS.include?(step)
+      @nationalities = get_nationalities_as_list
+    end
+
+    if SAVE_AND_RETURN_STEPS.include?(step)
+      if request.GET["save"]
+        @save_and_return_message = true
+        @save = "?save=1"
+      else
+        @save = ""
+      end
+    end
+
+    if step == SPONSOR_ID_TYPE
+      case @application.identification_type
+      when "passport"
+        @application.passport_identification_number = @application.identification_number
+      when "national_identity_card"
+        @application.id_identification_number = @application.identification_number
+      when "refugee_travel_document"
+        @application.refugee_identification_number = @application.identification_number
+      end
+    elsif ADULT_STEPS.include?(step)
+      Rails.logger.debug "Adult page!"
+
+      # Set properties based on values from hash of adults
+      @adult = @application.adults_at_address[params["key"]]
+
+      Rails.logger.debug "Adult: #{@adult}"
+
+      adult_dob = @adult["date_of_birth"]
+      adult_nationality = @adult["nationality"]
+      adult_id_type_and_number = @adult["id_type_and_number"]
+      if adult_dob.present? && adult_dob.length.positive?
+        @application.adult_date_of_birth = {
+          3 => Date.parse(adult_dob).day,
+          2 => Date.parse(adult_dob).month,
+          1 => Date.parse(adult_dob).year,
+        }
+      end
+      @application.adult_nationality = adult_nationality if adult_nationality.present? && adult_nationality.length.positive?
+      if adult_id_type_and_number.present? && adult_id_type_and_number.length.positive?
+        id_type_and_number = adult_id_type_and_number.split(" - ")
+        @application.adult_identification_type = id_type_and_number[0].to_s
+        case id_type_and_number[0].to_s
+        when "passport"
+          @application.adult_passport_identification_number = id_type_and_number[1].to_s
+        when "national_identity_card"
+          @application.adult_id_identification_number = id_type_and_number[1].to_s
+        when "refugee_travel_document"
+          @application.adult_refugee_identification_number = id_type_and_number[1].to_s
+        end
+      end
+    end
+
+    render "sponsor-a-child/steps/#{step}"
   end
 
   def handle_upload_uk

--- a/spec/controllers/unaccompanied_controller_spec.rb
+++ b/spec/controllers/unaccompanied_controller_spec.rb
@@ -1,6 +1,24 @@
 require "rails_helper"
 
 RSpec.describe UnaccompaniedController, type: :controller do
+  describe "display errors" do
+    let(:start_page) { "/sponsor-a-child" }
+
+    it "redirects back to the start when an application is not found" do
+      (1..5).each do |step|
+        get :display, params: { stage: step }
+
+        expect(response).to redirect_to(start_page)
+      end
+    end
+
+    it "redirects back to the start when the step is unknown" do
+      get :display, params: { stage: 999 }
+
+      expect(response).to redirect_to(start_page)
+    end
+  end
+
   describe "Submits" do
     uam = UnaccompaniedMinor.new
     uam.ip_address = "127.0.0.1".freeze


### PR DESCRIPTION
Our top sentry error (41 times) is when a user somehow `get`s to a step and the application is not found.
This PR traps the fault and redirects to the start page.

**Note** we were already trapping step out of range. An explicit test has been added for this.


EG: Try in a "clean" incognito window this link: [Step 1](https://apply-to-offer-homes-for-ukraine.service.gov.uk/sponsor-a-child/steps/1) - a terrible experience 😞
- **Currently**
![image](https://user-images.githubusercontent.com/1417516/189344624-fd29c5dc-0e3b-4521-9a14-d550ddc01a7d.png)
- **New Behaviour**
![image](https://user-images.githubusercontent.com/1417516/189345202-f01b27e8-1bb5-409b-bb21-b1bbab9d677d.png)


