### PR TITLE
Add target=_blank to all the external links missing it

### DIFF
--- a/app/views/sponsor-a-child/guidance.html.erb
+++ b/app/views/sponsor-a-child/guidance.html.erb
@@ -42,14 +42,14 @@
                 Ukraine certified consent form
               </li>
               <li class="app-step-nav__list-item js-list-item ">
-                <a data-position="1.1" class="app-step-nav__link js-link" href="https://www.gov.uk/government/publications/homes-for-ukraine-uk-sponsorship-arrangement-consent-form">UK sponsorship arrangement consent form</a>
+                <a data-position="1.1" class="app-step-nav__link js-link" href="https://www.gov.uk/government/publications/homes-for-ukraine-uk-sponsorship-arrangement-consent-form" target="_blank">UK sponsorship arrangement consent form</a>
               </li>
             </ol>
 
             <p class="app-step-nav__paragraph">Both forms need to be downloaded, completed and signed. The Ukrainian form also needs to be certified (this is explained in the guidance).</p>
 
             <p class="app-step-nav__paragraph">
-                <a data-position="1.2" class="app-step-nav__link js-link" href="https://www.gov.uk/guidance/homes-for-ukraine-guidance-for-sponsors-children-and-minors-applying-without-parents-or-legal-guardians#parent-or-legal-guardian-consent">Find out how to complete the consent forms</a>
+                <a data-position="1.2" class="app-step-nav__link js-link" href="https://www.gov.uk/guidance/homes-for-ukraine-guidance-for-sponsors-children-and-minors-applying-without-parents-or-legal-guardians#parent-or-legal-guardian-consent" target="_blank">Find out how to complete the consent forms</a>
             </p>
           </div>
 
@@ -111,7 +111,7 @@
             <p class="app-step-nav__paragraph">You must have received your ‘child sponsorship approval number’ before you can complete your sponsor’s section of their visa application.</p>
 
             <p class="app-step-nav__paragraph">
-              <a data-position="3.1" class="app-step-nav__link js-link" href="https://www.gov.uk/guidance/apply-for-a-visa-under-the-ukraine-sponsorship-scheme#applicants-aged-under-18">
+              <a data-position="3.1" class="app-step-nav__link js-link" href="https://www.gov.uk/guidance/apply-for-a-visa-under-the-ukraine-sponsorship-scheme#applicants-aged-under-18" target="_blank">
                 Read the guidance for children applying for a visa without a parent or legal guardian
               </a>
             </p>

--- a/app/views/sponsor-a-child/non_eligible.html.erb
+++ b/app/views/sponsor-a-child/non_eligible.html.erb
@@ -38,15 +38,15 @@
     <p class="govuk-body govuk-!-font-weight-bold">Other ways to sponsor someone from Ukraine</p>
 
     <p class="govuk-body">
-        <a class="govuk-link" href="https://www.gov.uk/guidance/apply-for-a-ukraine-family-scheme-visa">Sponsor a family member from Ukraine</a>
+        <a class="govuk-link" href="https://www.gov.uk/guidance/apply-for-a-ukraine-family-scheme-visa" target="_blank">Sponsor a family member from Ukraine</a>
     </p>
 
     <p class="govuk-body">
-        <a class="govuk-link" href="https://www.gov.uk/guidance/apply-for-a-visa-under-the-ukraine-sponsorship-scheme">Sponsor someone you already know from Ukraine</a>
+        <a class="govuk-link" href="https://www.gov.uk/guidance/apply-for-a-visa-under-the-ukraine-sponsorship-scheme" target="_blank">Sponsor someone you already know from Ukraine</a>
     </p>
     
     <p class="govuk-body">
-        <a class="govuk-link" href="https://www.gov.uk/register-interest-homes-ukraine">Register your interest with Homes for Ukraine</a>
+        <a class="govuk-link" href="https://www.gov.uk/register-interest-homes-ukraine" target="_blank">Register your interest with Homes for Ukraine</a>
     </p>
   </div>
 </div>

--- a/app/views/sponsor-a-child/steps/35.html.erb
+++ b/app/views/sponsor-a-child/steps/35.html.erb
@@ -13,7 +13,7 @@
      </p>
 
      <ul class="govuk-list govuk-list--bullet">
-        <li><a class="govuk-link" href="https://www.gov.uk/government/publications/homes-for-ukraine-uk-sponsorship-arrangement-consent-form">UK sponsorship arrangement consent form</a> on the next page</li>
+        <li><a class="govuk-link" href="https://www.gov.uk/government/publications/homes-for-ukraine-uk-sponsorship-arrangement-consent-form" target="_blank">UK sponsorship arrangement consent form</a> on the next page</li>
         <li>'Ukraine certified consent form' on another page</li>
      </ul>
 
@@ -21,7 +21,7 @@
         These forms must be completed by at least one parent or legal guardian.
         <br/>
         <br/>
-        <a class="govuk-link" href="https://www.gov.uk/guidance/homes-for-ukraine-guidance-for-sponsors-children-and-minors-applying-without-parents-or-legal-guardians#parent-or-legal-guardian-consent">Read guidance about parental consent forms.</a>
+        <a class="govuk-link" href="https://www.gov.uk/guidance/homes-for-ukraine-guidance-for-sponsors-children-and-minors-applying-without-parents-or-legal-guardians#parent-or-legal-guardian-consent" target="_blank">Read guidance about parental consent forms.</a>
      </p>
 
     <%= form_for @application, url: "/sponsor-a-child/steps/35", method: :post do |f| %>

--- a/app/views/sponsor-a-child/steps/36.html.erb
+++ b/app/views/sponsor-a-child/steps/36.html.erb
@@ -33,7 +33,7 @@
                 <br/>
                 You can only upload 1 file. If you have multiple files, please use an app or website to combine the documents into a single PDF file. <br/>
                 <br/>
-                If the parents or guardians are struggling to complete the form and send it to you, they should <a class="govuk-link" href="https://www.gov.uk/guidance/homes-for-ukraine-guidance-for-parents-or-legal-guardians-children-and-minors-applying-without-parents#parental-or-legal-guardian-consent-1"> read the guidance on completing parental consent forms.</a>
+                If the parents or guardians are struggling to complete the form and send it to you, they should <a class="govuk-link" href="https://www.gov.uk/guidance/homes-for-ukraine-guidance-for-parents-or-legal-guardians-children-and-minors-applying-without-parents#parental-or-legal-guardian-consent-1" target="_blank"> read the guidance on completing parental consent forms.</a>
 
                 </div>
 

--- a/app/views/sponsor-a-child/steps/37.html.erb
+++ b/app/views/sponsor-a-child/steps/37.html.erb
@@ -29,7 +29,7 @@
                 <br/>
                 You can only upload 1 file. If you have multiple files, please use an app or website to combine the documents into a single PDF file. <br/>
                 <br/>
-                If the parents or guardians are struggling to complete the form and send it to you, they should <a class="govuk-link" href="https://www.gov.uk/guidance/homes-for-ukraine-guidance-for-parents-or-legal-guardians-children-and-minors-applying-without-parents#parental-or-legal-guardian-consent-1"> read the guidance on completing parental consent forms.</a>
+                If the parents or guardians are struggling to complete the form and send it to you, they should <a class="govuk-link" href="https://www.gov.uk/guidance/homes-for-ukraine-guidance-for-parents-or-legal-guardians-children-and-minors-applying-without-parents#parental-or-legal-guardian-consent-1" target="_blank"> read the guidance on completing parental consent forms.</a>
                 </div>
 
             </details>


### PR DESCRIPTION
I only searched the following subfolders: `sponsor-a-child` and `fraud`, not the `organisation` or `individual` views for I don't think they're in scope for this ticket