### PR TITLE
Add consent uploader ENV var credentials to sidekiq

### DIFF
--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -198,6 +198,8 @@ jobs:
           CF_SPACE: ${{ secrets.CF_SPACE }}
           CF_ORG: ${{ secrets.CF_ORG }}
           APP_NAME: ukraine-sponsor-resettlement-staging-sidekiq
+          CONSENT_UPLOAD_USER: ${{ secrets.CONSENT_UPLOAD_USER }}
+          CONSENT_UPLOAD_PASS: ${{ secrets.CONSENT_UPLOAD_PASS }}
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           BASIC_AUTH_USER: ${{ secrets.BASIC_AUTH_USER }}
           BASIC_AUTH_PASS: ${{ secrets.BASIC_AUTH_PASS }}
@@ -224,6 +226,8 @@ jobs:
           cf auth
           cf target -o $CF_ORG -s $CF_SPACE
           cf set-env $APP_NAME RAILS_MASTER_KEY $RAILS_MASTER_KEY
+          cf set-env $APP_NAME CONSENT_UPLOAD_USER $CONSENT_UPLOAD_USER
+          cf set-env $APP_NAME CONSENT_UPLOAD_PASS $CONSENT_UPLOAD_PASS
           cf set-env $APP_NAME BASIC_AUTH_USER $BASIC_AUTH_USER
           cf set-env $APP_NAME BASIC_AUTH_PASS $BASIC_AUTH_PASS
           cf set-env $APP_NAME REMOTE_API_URL $REMOTE_API_URL
@@ -330,6 +334,8 @@ jobs:
           CF_SPACE: ${{ secrets.CF_SPACE }}
           CF_ORG: ${{ secrets.CF_ORG }}
           APP_NAME: ukraine-sponsor-resettlement-production-sidekiq
+          CONSENT_UPLOAD_USER: ${{ secrets.CONSENT_UPLOAD_USER }}
+          CONSENT_UPLOAD_PASS: ${{ secrets.CONSENT_UPLOAD_PASS }}
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           REMOTE_API_URL: ${{ secrets.REMOTE_API_URL }}
           REMOTE_API_TOKEN: ${{ secrets.REMOTE_API_TOKEN }}
@@ -354,6 +360,8 @@ jobs:
           cf auth
           cf target -o $CF_ORG -s $CF_SPACE
           cf set-env $APP_NAME RAILS_MASTER_KEY $RAILS_MASTER_KEY
+          cf set-env $APP_NAME CONSENT_UPLOAD_USER $CONSENT_UPLOAD_USER
+          cf set-env $APP_NAME CONSENT_UPLOAD_PASS $CONSENT_UPLOAD_PASS
           cf set-env $APP_NAME REMOTE_API_URL $REMOTE_API_URL
           cf set-env $APP_NAME REMOTE_API_TOKEN $REMOTE_API_TOKEN
           cf set-env $APP_NAME REMOTE_API_TOKEN_UAM $REMOTE_API_TOKEN_UAM


### PR DESCRIPTION
Following a live sidekiq issue, these env vars are required in sidekiq due to their placement, and fetch call, in the FoundryConsentUploadController

The fix was achieved via the cf command line - this PR ensures they are in the pipeline.
Github vars have also been checked / configured.