### PR TITLE
updating email input fields to have labels

### DIFF
--- a/app/views/sponsor-a-child/steps/14.html.erb
+++ b/app/views/sponsor-a-child/steps/14.html.erb
@@ -11,14 +11,12 @@
     <p class="govuk-body"><%= t('email.full', scope: "unaccompanied_minor.questions")%></p>
     
       <%= f.govuk_text_field :email,
-                             label: { text: "", hidden: true },
-                             hint: { text: t('email.hint', scope: "unaccompanied_minor.questions")},
+                             label: { text:  t('email.label_email', scope: "unaccompanied_minor.questions")},
                              type: "email"
       %>
 
       <%= f.govuk_text_field :email_confirm,
-                             label: { text: "", hidden: true },
-                             hint: { text: t('email.confirm', scope: "unaccompanied_minor.questions")},
+                             label: { text: t('email.label_confirm_email', scope: "unaccompanied_minor.questions") },
                              type: "email"
       %>
       

--- a/app/views/sponsor-a-child/steps/15.html.erb
+++ b/app/views/sponsor-a-child/steps/15.html.erb
@@ -12,8 +12,7 @@
 
 
       <%= f.govuk_text_field :phone_number,
-        label: { text: "", hidden: true },
-        hint: { text: t('phone_number.hint', scope: "unaccompanied_minor.questions")},
+        label: { text: t('phone_number.label', scope: "unaccompanied_minor.questions") },
         type: "tel"
       %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -336,8 +336,8 @@ en:
       email:
         short: Enter your email address
         full: Enter an email address that you have access to, so you can save and continue your application later.
-        hint: Email address
-        confirm: Confirm email
+        label_email: Email address
+        label_confirm_email: Confirm email address
       phone_number:
         short: Enter your UK phone number
         full: Enter a phone number that you have access to, so you can save and continue your application later.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -341,7 +341,7 @@ en:
       phone_number:
         short: Enter your UK phone number
         full: Enter a phone number that you have access to, so you can save and continue your application later.
-        hint: UK phone number
+        label: UK phone number
       identity_documents:
         short: Sponsor identity documents
         full: Do you have any of these identity documents?

--- a/spec/system/confirm_page_spec.rb
+++ b/spec/system/confirm_page_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Unaccompanied minor other adults", type: :system do
       click_button("Continue")
 
       expect(page).to have_content("Enter your UK phone number")
-      fill_in("Phone_number", with: "07123123123")
+      fill_in("UK phone number", with: "07123123123")
       fill_in("Confirm phone number", with: "07123123123")
       click_button("Continue")
 

--- a/spec/system/token_based_resume_controller_spec.rb
+++ b/spec/system/token_based_resume_controller_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe TokenBasedResumeController, type: :system do
 
       visit "/sponsor-a-child/save-and-return"
 
-      expect(page).to have_content(I18n.t("email.full", scope: "unaccompanied_minor.questions"))
+      expect(page).to have_content(I18n.t("email.short", scope: "unaccompanied_minor.questions"))
     end
 
     it "redirects the user to additional details form if phone number info are missing" do

--- a/spec/system/unaccompanied_minor_spec.rb
+++ b/spec/system/unaccompanied_minor_spec.rb
@@ -317,7 +317,7 @@ RSpec.describe "Unaccompanied minor expression of interest", type: :system do
       fill_in("unaccompanied_minor[email_confirm]", with: "jane.doe@test.com")
       click_button("Continue")
 
-      fill_in("Phone_number", with: "07777 888 999")
+      fill_in("UK phone number", with: "07777 888 999")
       fill_in("Confirm phone number", with: "07777 888 999")
       click_button("Continue")
 
@@ -622,7 +622,7 @@ RSpec.describe "Unaccompanied minor expression of interest", type: :system do
 
       click_button("Continue")
 
-      fill_in("Phone_number", with: "07777 888 999")
+      fill_in("UK phone number", with: "07777 888 999")
 
       # rubocop:disable RSpec/AnyInstance
       allow_any_instance_of(UnaccompaniedController).to receive(:last_seen_activity_threshold).and_return(- 10.seconds)


### PR DESCRIPTION
PR 1005[https://digital.dclg.gov.uk/jira/browse/UKRSS-1005](url)

Updating email and phone number input fields to have labels instead of hints.  Updated tests