### PR TITLE
add error box to resend link page

### DIFF
--- a/app/views/token-based-resume/save_return_resend_link.html.erb
+++ b/app/views/token-based-resume/save_return_resend_link.html.erb
@@ -6,6 +6,10 @@
     <% else %>
       <h1 class="govuk-heading-l">Request a secure link to your application</h1>
     <% end %>
+   <%= form_for @application, url: "/sponsor-a-child/resend-link", method: :post do |f| %>
+
+    <%= f.govuk_error_summary link_base_errors_to: :email %>
+    <% end %>
 
     <p class="govuk-body">
         Confirm your email address and we will send you a new one so you can continue your application.
@@ -13,8 +17,7 @@
 
     <%= form_for @application, url: "/sponsor-a-child/resend-link", method: :post do |f| %>
       <%= f.govuk_text_field :email,
-                             label: { text: t('email.full', scope: "unaccompanied_minor.questions"), size: 'm', hidden: true },
-                             hint: { text: t('email.hint', scope: "unaccompanied_minor.questions")},
+                             label: { text: t('email.label_email', scope: "unaccompanied_minor.questions") },
                              type: "email"
       %>
 

--- a/spec/system/token_based_resume_controller_spec.rb
+++ b/spec/system/token_based_resume_controller_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe TokenBasedResumeController, type: :system do
 
       visit "/sponsor-a-child/save-and-return/resend-link"
 
-      fill_in("Enter an email address that you have access to, so you can save and continue your application later.", with: email)
+      fill_in("Email address", with: email)
       click_button("Send Link")
 
       expect(page).to have_content("We've sent the link to #{email_scrambled}")
@@ -148,7 +148,7 @@ RSpec.describe TokenBasedResumeController, type: :system do
 
       visit "/sponsor-a-child/save-and-return/resend-link"
 
-      fill_in("Enter an email address that you have access to, so you can save and continue your application later.", with: email)
+      fill_in("Email address", with: email)
       click_button("Send Link")
 
       expect(page).to have_content("We've sent the link to #{email_scrambled}")
@@ -159,7 +159,7 @@ RSpec.describe TokenBasedResumeController, type: :system do
 
       visit "/sponsor-a-child/save-and-return/resend-link"
 
-      fill_in("Enter an email address that you have access to, so you can save and continue your application later.", with: "")
+      fill_in("Email address", with: "")
       click_button("Send Link")
 
       expect(page).to have_content(I18n.t(:invalid_email, scope: :error))


### PR DESCRIPTION
PR [1043](https://digital.dclg.gov.uk/jira/browse/UKRSS-1043)

Adds an error box to the /sponsor-a-child/save-and-return/confirm page.  Also changes a hint to be a label with appropriate text.