### PR TITLE
1035 validation for identity question

### DIFF
--- a/app/controllers/unaccompanied_controller.rb
+++ b/app/controllers/unaccompanied_controller.rb
@@ -233,6 +233,8 @@ class UnaccompaniedController < ApplicationController
 
       if !phone_number_valid?(@application.phone_number)
         @application.errors.add(:phone_number, I18n.t(:invalid_phone_number, scope: :error))
+      elsif !uk_mobile_number?(@application.phone_number)
+        @application.errors.add(:phone_number, I18n.t(:non_uk_number, scope: :error))
       elsif @application.phone_number != @application.phone_number_confirm
         @application.errors.add(:phone_number_confirm, I18n.t(:phone_numbers_different, scope: :error))
       end

--- a/app/controllers/unaccompanied_controller.rb
+++ b/app/controllers/unaccompanied_controller.rb
@@ -14,7 +14,7 @@ class UnaccompaniedController < ApplicationController
   SPONSOR_EMAIL = 14
   SPONSOR_PHONE_NUMBER = 15
   SPONSOR_ID_TYPE = 16
-  SPONSOR_ID_EXPLAIN = 17
+  SPONSOR_ID_MISSING_EXPLANATION = 17
   SPONSOR_DATE_OF_BIRTH = 18
   SPONSOR_NATIONALITY = 19
   SPONSOR_OTHER_NATIONALITIES_CHOICE = 20
@@ -289,11 +289,15 @@ class UnaccompaniedController < ApplicationController
       end
     end
 
-    if current_step == SPONSOR_ID_EXPLAIN && @no_identification_reason.blank?
-      @application.errors.add(:no_identification_reason, I18n.t(:no_identity_error, scope: :error))
+    if current_step == SPONSOR_ID_MISSING_EXPLANATION
 
-      render_current_step
-      return
+      explanation = params["unaccompanied_minor"]["no_identification_reason"]
+      if explanation.blank?
+        @application.errors.add(:no_identification_reason, I18n.t(:no_identity_error, scope: :error))
+
+        render_current_step
+        return
+      end
     end
 
     if current_step == SPONSOR_DATE_OF_BIRTH

--- a/app/controllers/unaccompanied_controller.rb
+++ b/app/controllers/unaccompanied_controller.rb
@@ -14,6 +14,7 @@ class UnaccompaniedController < ApplicationController
   SPONSOR_EMAIL = 14
   SPONSOR_PHONE_NUMBER = 15
   SPONSOR_ID_TYPE = 16
+  SPONSOR_ID_EXPLAIN = 17
   SPONSOR_DATE_OF_BIRTH = 18
   SPONSOR_NATIONALITY = 19
   SPONSOR_OTHER_NATIONALITIES_CHOICE = 20
@@ -286,6 +287,13 @@ class UnaccompaniedController < ApplicationController
         render_current_step
         return
       end
+    end
+
+    if current_step == SPONSOR_ID_EXPLAIN && @no_identification_reason.blank?
+      @application.errors.add(:no_identification_reason, I18n.t(:no_identity_error, scope: :error))
+
+      render_current_step
+      return
     end
 
     if current_step == SPONSOR_DATE_OF_BIRTH

--- a/app/controllers/unaccompanied_controller.rb
+++ b/app/controllers/unaccompanied_controller.rb
@@ -234,8 +234,6 @@ class UnaccompaniedController < ApplicationController
 
       if !phone_number_valid?(@application.phone_number)
         @application.errors.add(:phone_number, I18n.t(:invalid_phone_number, scope: :error))
-      elsif !uk_mobile_number?(@application.phone_number)
-        @application.errors.add(:phone_number, I18n.t(:non_uk_number, scope: :error))
       elsif @application.phone_number != @application.phone_number_confirm
         @application.errors.add(:phone_number_confirm, I18n.t(:phone_numbers_different, scope: :error))
       end

--- a/app/models/concerns/common_validations.rb
+++ b/app/models/concerns/common_validations.rb
@@ -64,7 +64,7 @@ module CommonValidations
   end
 
   def uk_mobile_number?(value)
-    valid_uk_number = /(^\+447[0-9]{9}$)|(^07[0-9]{9}$)|(^447[0-9]{9}$)/.freeze
+    valid_uk_number = /(^\+447[0-9]{9}$)|(^07[0-9]{9}$)|(^447[0-9]{9}$)/
     blanks_removed = value.gsub(/\s+/, "")
     value.present? && blanks_removed.match?(valid_uk_number)
   end

--- a/app/models/concerns/common_validations.rb
+++ b/app/models/concerns/common_validations.rb
@@ -62,4 +62,10 @@ module CommonValidations
   def phone_number_valid?(value)
     value.present? && value.scan(/\d/).join.length > 10 && value.scan(/\d/).join.length < 14 && value.match(/[0-9 -+]+$/)
   end
+
+  def uk_mobile_number?(value)
+    valid_uk_number = /(^\+447[0-9]{9}$)|(^07[0-9]{9}$)|(^447[0-9]{9}$)/.freeze
+    blanks_removed = value.gsub(/\s+/, "")
+    value.present? && blanks_removed.match?(valid_uk_number)
+  end
 end

--- a/app/models/concerns/common_validations.rb
+++ b/app/models/concerns/common_validations.rb
@@ -62,10 +62,4 @@ module CommonValidations
   def phone_number_valid?(value)
     value.present? && value.scan(/\d/).join.length > 10 && value.scan(/\d/).join.length < 14 && value.match(/[0-9 -+]+$/)
   end
-
-  def uk_mobile_number?(value)
-    valid_uk_number = /(^\+447[0-9]{9}$)|(^07[0-9]{9}$)|(^447[0-9]{9}$)/
-    blanks_removed = value.gsub(/\s+/, "")
-    value.present? && blanks_removed.match?(valid_uk_number)
-  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -496,6 +496,7 @@ en:
     invalid_email: You must enter a valid email address
     invalid_organisation_name: Please enter a valid organisation name
     invalid_phone_number: You must enter a valid phone number
+    non_uk_number: You must enter a UK mobile number
     invalid_minor_fullname: You must enter the child's full name
     invalid_fullname: You must enter your full name
     invalid_family_name: You must enter a valid family name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -347,8 +347,8 @@ en:
         full: Do you have any of these identity documents?
       no_identity_documents:
         short: Sponsor no official identity documents
-        full: What can you use to prove your identity?
-        hint: Tell us if you have another document that can prove your identity, for example, a drivers license or birth certificate.
+        full: Can you prove your identity?
+        hint: Tell us if you have a document that can prove your identity, for example, a drivers license or birth certificate. If you don’t have any proof of identity, please explain your situation in detail.
       sponsor_date_of_birth:
         short: Date of birth
         full: Enter your date of birth
@@ -528,3 +528,4 @@ en:
     min_chars_digits: You must enter at least 6 characters (numbers or letters)
     emails_different: Emails must match
     phone_numbers_different: Phone numbers must match
+    no_identity_error: Tell us how you can prove your identity, or why you cannot.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -496,7 +496,6 @@ en:
     invalid_email: You must enter a valid email address
     invalid_organisation_name: Please enter a valid organisation name
     invalid_phone_number: You must enter a valid phone number
-    non_uk_number: You must enter a UK mobile number
     invalid_minor_fullname: You must enter the child's full name
     invalid_fullname: You must enter your full name
     invalid_family_name: You must enter a valid family name

--- a/spec/system/sponsor_additional_details_spec.rb
+++ b/spec/system/sponsor_additional_details_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Sponsor additional details", type: :system do
       expect(page).to have_field("Year", with: dob.year)
     end
 
-    it "validates step 17 on blank submission" do
+    it "validates other identity documents field on blank submission" do
       navigate_to_additional_details
       choose("I don't have any of these")
       click_button("Continue")
@@ -54,6 +54,20 @@ RSpec.describe "Sponsor additional details", type: :system do
       click_button("Continue")
 
       expect(page).to have_content("Error: Tell us how you can prove your identity, or why you cannot.")
+    end
+
+    it "validates other identity documents field on any submission" do
+      navigate_to_additional_details
+      choose("I don't have any of these")
+      click_button("Continue")
+
+      expect(page).to have_content("Can you prove your identity?")
+
+      fill_in("unaccompanied-minor-no-identification-reason-field", with: "Hello")
+
+      click_button("Continue")
+
+      expect(page).to have_content("Enter your date of birth")
     end
   end
 

--- a/spec/system/sponsor_additional_details_spec.rb
+++ b/spec/system/sponsor_additional_details_spec.rb
@@ -43,6 +43,18 @@ RSpec.describe "Sponsor additional details", type: :system do
       expect(page).to have_field("Month", with: dob.month)
       expect(page).to have_field("Year", with: dob.year)
     end
+
+    it "validates step 17 on blank submission" do
+      navigate_to_additional_details
+      choose("I don't have any of these")
+      click_button("Continue")
+
+      expect(page).to have_content("Can you prove your identity?")
+
+      click_button("Continue")
+
+      expect(page).to have_content("Error: Tell us how you can prove your identity, or why you cannot.")
+    end
   end
 
   def navigate_to_additional_details

--- a/spec/system/uam_sponsor_contact_details_spec.rb
+++ b/spec/system/uam_sponsor_contact_details_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "Sponsor contact details", type: :system do
   let(:sponsor_email) { "sponsor@example.com" }
   let(:nonmatching_sponsor_email) { "notmatching@example.com" }
   let(:phone_page_content) { "Enter your UK phone number" }
+  let(:task_list_content) {"Apply for approval to provide a safe home for a child from Ukraine"}
 
   describe "Sponsors contact details don't match" do
     it "shows error message for not matching email addresses" do
@@ -89,7 +90,15 @@ RSpec.describe "Sponsor contact details", type: :system do
       expect(page).to have_content(phone_page_content)
       
       fill_in_phone_numbers_and_continue(phone_number: "447312312312", phone_number_confirm: "447312312312")
-      expect(page).to have_content("Apply for approval to provide a safe home for a child from Ukraine")
+      expect(page).to have_content(task_list_content)
+    end
+
+    it "recognises UK mobile number with +447 rather than 07" do 
+      fill_in_email_and_continue
+      expect(page).to have_content(phone_page_content)
+      
+      fill_in_phone_numbers_and_continue(phone_number: "+447312312312", phone_number_confirm: "+447312312312")
+      expect(page).to have_content(task_list_content)
     end
 
     def fill_in_phone_numbers_and_continue(phone_number: valid_phone_number, phone_number_confirm: valid_phone_number)

--- a/spec/system/uam_sponsor_contact_details_spec.rb
+++ b/spec/system/uam_sponsor_contact_details_spec.rb
@@ -77,30 +77,6 @@ RSpec.describe "Sponsor contact details", type: :system do
       expect(page).to have_field("Confirm phone number", with: valid_phone_number)
     end
 
-    it "validates that the phone number is UK" do
-      fill_in_email_and_continue
-      expect(page).to have_content(phone_page_content)
-
-      fill_in_phone_numbers_and_continue(phone_number: "12312312312", phone_number_confirm: "12312312312")
-      expect(page).to have_content("Error: You must enter a UK mobile number")
-    end
-
-    it "recognises UK mobile number with 447 rather than 07" do
-      fill_in_email_and_continue
-      expect(page).to have_content(phone_page_content)
-
-      fill_in_phone_numbers_and_continue(phone_number: "447312312312", phone_number_confirm: "447312312312")
-      expect(page).to have_content(task_list_content)
-    end
-
-    it "recognises UK mobile number with +447 rather than 07" do
-      fill_in_email_and_continue
-      expect(page).to have_content(phone_page_content)
-
-      fill_in_phone_numbers_and_continue(phone_number: "+447312312312", phone_number_confirm: "+447312312312")
-      expect(page).to have_content(task_list_content)
-    end
-
     def fill_in_phone_numbers_and_continue(phone_number: valid_phone_number, phone_number_confirm: valid_phone_number)
       fill_in("unaccompanied-minor-phone-number-field", with: phone_number)
       fill_in("Confirm phone number", with: phone_number_confirm)

--- a/spec/system/uam_sponsor_contact_details_spec.rb
+++ b/spec/system/uam_sponsor_contact_details_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Sponsor contact details", type: :system do
   let(:sponsor_email) { "sponsor@example.com" }
   let(:nonmatching_sponsor_email) { "notmatching@example.com" }
   let(:phone_page_content) { "Enter your UK phone number" }
-  let(:task_list_content) {"Apply for approval to provide a safe home for a child from Ukraine"}
+  let(:task_list_content) { "Apply for approval to provide a safe home for a child from Ukraine" }
 
   describe "Sponsors contact details don't match" do
     it "shows error message for not matching email addresses" do
@@ -77,26 +77,26 @@ RSpec.describe "Sponsor contact details", type: :system do
       expect(page).to have_field("Confirm phone number", with: valid_phone_number)
     end
 
-    it "validates that the phone number is UK" do 
+    it "validates that the phone number is UK" do
       fill_in_email_and_continue
       expect(page).to have_content(phone_page_content)
-      
+
       fill_in_phone_numbers_and_continue(phone_number: "12312312312", phone_number_confirm: "12312312312")
       expect(page).to have_content("Error: You must enter a UK mobile number")
     end
 
-    it "recognises UK mobile number with 447 rather than 07" do 
+    it "recognises UK mobile number with 447 rather than 07" do
       fill_in_email_and_continue
       expect(page).to have_content(phone_page_content)
-      
+
       fill_in_phone_numbers_and_continue(phone_number: "447312312312", phone_number_confirm: "447312312312")
       expect(page).to have_content(task_list_content)
     end
 
-    it "recognises UK mobile number with +447 rather than 07" do 
+    it "recognises UK mobile number with +447 rather than 07" do
       fill_in_email_and_continue
       expect(page).to have_content(phone_page_content)
-      
+
       fill_in_phone_numbers_and_continue(phone_number: "+447312312312", phone_number_confirm: "+447312312312")
       expect(page).to have_content(task_list_content)
     end

--- a/spec/system/uam_sponsor_contact_details_spec.rb
+++ b/spec/system/uam_sponsor_contact_details_spec.rb
@@ -76,6 +76,14 @@ RSpec.describe "Sponsor contact details", type: :system do
       expect(page).to have_field("Confirm phone number", with: valid_phone_number)
     end
 
+    it "validates that the phone number is UK" do 
+      fill_in_email_and_continue
+      expect(page).to have_content(phone_page_content)
+      
+      fill_in_phone_numbers_and_continue(phone_number: "12312312312", phone_number_confirm: "12312312312")
+      expect(page).to have_content("Error: You must enter a UK mobile number")
+    end
+
     def fill_in_phone_numbers_and_continue(phone_number: valid_phone_number, phone_number_confirm: valid_phone_number)
       fill_in("unaccompanied-minor-phone-number-field", with: phone_number)
       fill_in("Confirm phone number", with: phone_number_confirm)

--- a/spec/system/uam_sponsor_contact_details_spec.rb
+++ b/spec/system/uam_sponsor_contact_details_spec.rb
@@ -84,6 +84,14 @@ RSpec.describe "Sponsor contact details", type: :system do
       expect(page).to have_content("Error: You must enter a UK mobile number")
     end
 
+    it "recognises UK mobile number with 447 rather than 07" do 
+      fill_in_email_and_continue
+      expect(page).to have_content(phone_page_content)
+      
+      fill_in_phone_numbers_and_continue(phone_number: "447312312312", phone_number_confirm: "447312312312")
+      expect(page).to have_content("Apply for approval to provide a safe home for a child from Ukraine")
+    end
+
     def fill_in_phone_numbers_and_continue(phone_number: valid_phone_number, phone_number_confirm: valid_phone_number)
       fill_in("unaccompanied-minor-phone-number-field", with: phone_number)
       fill_in("Confirm phone number", with: phone_number_confirm)

--- a/spec/system/unaccompanied_minor_spec.rb
+++ b/spec/system/unaccompanied_minor_spec.rb
@@ -928,7 +928,7 @@ RSpec.describe "Unaccompanied minor expression of interest", type: :system do
       choose("I don't have any of these")
 
       click_button("Continue")
-      expect(page).to have_content("What can you use to prove your identity?")
+      expect(page).to have_content("Can you prove your identity?")
 
       saved_application = UnaccompaniedMinor.find_by_reference(application.reference)
       expect(saved_application.identification_type).to eq("none")


### PR DESCRIPTION
PR for ticket [1035](https://digital.dclg.gov.uk/jira/browse/UKRSS-1035)

Adds validation for sponsor Identity document other page. If the field is blank it won't let the user continue. 

Old view: 
<img width="386" alt="Screenshot 2022-09-28 at 12 28 07" src="https://user-images.githubusercontent.com/98767768/192767927-79672e0a-9728-4d14-a4c0-dace03578c76.png">

New view:
<img width="830" alt="Screenshot 2022-09-28 at 12 27 54" src="https://user-images.githubusercontent.com/98767768/192768004-94911768-0526-4952-941d-9a28d3b0cabf.png">
