### PR TITLE
Checks that application ref is present in session for endpoints which expect it

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ require "action_view/railtie"
 # require "action_cable/engine"
 # require "sprockets/railtie"
 # require "rails/test_unit/railtie"
-
+require_relative "../lib/session_check"
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
@@ -31,5 +31,6 @@ module UkraineSponsorResettlement
     config.exceptions_app = self.routes
 
     config.active_job.queue_adapter = :sidekiq
+    config.middleware.use SessionCheck
   end
 end

--- a/lib/session_check.rb
+++ b/lib/session_check.rb
@@ -1,0 +1,44 @@
+class SessionCheck
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    # Check that the user's session contains correct data to be valid.
+    # Many of the controllers for UAM require app_reference to be present
+    # in the user's session. If the required data is not present, redirect
+    # the user to the start of the UAM journey.
+
+    if sessioncheck(env)
+      @app.call(env)
+    else
+      [302, { "Location" => "/sponsor-a-child" }, []]
+    end
+  end
+
+  def sessioncheck(env)
+    # If incoming request path matches any of the regexps below and
+    # if the user's session does not have an app_reference then
+    # return false, else return true
+
+    reference_required_paths = [
+      /\/sponsor-a-child\/task-list/,
+      /\/sponsor-a-child\/save_or_cancel/,
+      /\/sponsor-a-child\/cancel-application/,
+      /\/sponsor-a-child\/check-answers/,
+      /\/sponsor-a-child\/upload-uk\/\d+/,
+      /\/sponsor-a-child\/upload-ukraine\/\d+/,
+      /\/sponsor-a-child\/remove\/\w+/,
+      /\/sponsor-a-child\/remove-other-name\/\w+\/\w+/,
+      /\/sponsor-a-child\/remove-other-nationality\/\w+/,
+    ]
+
+    session_ok = true
+    reference_required_paths.each do |re|
+      if env["PATH_INFO"].match?(re) && env["rack.session"][:app_reference].blank?
+        session_ok = false
+      end
+    end
+    session_ok
+  end
+end

--- a/spec/system/unaccompanied_minor_spec.rb
+++ b/spec/system/unaccompanied_minor_spec.rb
@@ -17,6 +17,22 @@ RSpec.describe "Unaccompanied minor expression of interest", type: :system do
     end
   end
 
+  describe "app_reference is checked in middleware" do
+    it "can view the task list when app_reference is present" do
+      new_application = UnaccompaniedMinor.new
+      new_application.save!
+      page.set_rack_session(app_reference: new_application.reference)
+      visit "/sponsor-a-child/task-list"
+      expect(page).to have_current_path("/sponsor-a-child/task-list")
+      expect(page).to have_content(task_list_content)
+    end
+
+    it "redirected to sponsor-a-child when app_reference is not present" do
+      visit "/sponsor-a-child/task-list"
+      expect(page).to have_current_path("/sponsor-a-child")
+    end
+  end
+
   describe "cancelling the application" do
     it "updates the application as cancelled" do
       new_application = UnaccompaniedMinor.new


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/UKRSS-1033

Covers UAM user journey. User will be redirected to /sponsor-a-child (the beginning of the user journey) if the required appllication reference is not found in their session.