### PR TITLE
991 - Add schema and output for Sponsor, Section 1 additional details

### DIFF
--- a/app/models/concerns/unaccompanied_minor_transfer_adapter.rb
+++ b/app/models/concerns/unaccompanied_minor_transfer_adapter.rb
@@ -48,6 +48,7 @@ class UnaccompaniedMinorTransferAdapter
 
   OPTIONAL_KEYS = %i[
     other_names
+    no_identification_reason
   ].freeze
 
   def self.to_json(uam_hash)

--- a/app/models/concerns/unaccompanied_minor_transfer_adapter.rb
+++ b/app/models/concerns/unaccompanied_minor_transfer_adapter.rb
@@ -46,7 +46,16 @@ class UnaccompaniedMinorTransferAdapter
     version
   ].freeze
 
+  OPTIONAL_KEYS = %i[
+    other_names
+  ].freeze
+
   def self.to_json(uam_hash)
-    JSON.generate(uam_hash.slice(*REQUIRED_KEYS))
+    all_keys = REQUIRED_KEYS + OPTIONAL_KEYS
+    Rails.logger.debug JSON.pretty_generate(uam_hash)
+    Rails.logger.debug "***************************************************"
+    Rails.logger.debug JSON.pretty_generate(uam_hash.slice(*all_keys))
+
+    JSON.generate(uam_hash.slice(*all_keys))
   end
 end

--- a/app/models/concerns/unaccompanied_minor_transfer_adapter.rb
+++ b/app/models/concerns/unaccompanied_minor_transfer_adapter.rb
@@ -49,6 +49,7 @@ class UnaccompaniedMinorTransferAdapter
   OPTIONAL_KEYS = %i[
     other_names
     no_identification_reason
+    other_nationalities
   ].freeze
 
   def self.to_json(uam_hash)

--- a/app/models/concerns/unaccompanied_minor_transfer_adapter.rb
+++ b/app/models/concerns/unaccompanied_minor_transfer_adapter.rb
@@ -54,9 +54,9 @@ class UnaccompaniedMinorTransferAdapter
 
   def self.to_json(uam_hash)
     all_keys = REQUIRED_KEYS + OPTIONAL_KEYS
-    Rails.logger.debug JSON.pretty_generate(uam_hash)
-    Rails.logger.debug "***************************************************"
-    Rails.logger.debug JSON.pretty_generate(uam_hash.slice(*all_keys))
+    # puts JSON.pretty_generate(uam_hash)
+    # puts "***************************************************"
+    # puts JSON.pretty_generate(uam_hash.slice(*all_keys))
 
     JSON.generate(uam_hash.slice(*all_keys))
   end

--- a/spec/support/json_schema/unaccompanied_minor.json
+++ b/spec/support/json_schema/unaccompanied_minor.json
@@ -188,8 +188,11 @@
     },
     "other_names": {
       "type": "array",
-      "minItems": 1
-    },
+      "minItems": 1,
+      "items": {
+                "type": "array"
+               }
+     },
     "no_identification_reason": {
       "type": "string"
     }

--- a/spec/support/json_schema/unaccompanied_minor.json
+++ b/spec/support/json_schema/unaccompanied_minor.json
@@ -185,6 +185,10 @@
     },
     "version": {
       "type": "number"
+    },
+    "other_names": {
+      "type": "array",
+      "minItems": 1
     }
   },
   "$defs": {

--- a/spec/support/json_schema/unaccompanied_minor.json
+++ b/spec/support/json_schema/unaccompanied_minor.json
@@ -195,7 +195,14 @@
      },
     "no_identification_reason": {
       "type": "string"
-    }
+    },
+    "other_nationalities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+                "type": "array"
+               }
+     }
   },
   "$defs": {
     "yes_or_no": {

--- a/spec/support/json_schema/unaccompanied_minor.json
+++ b/spec/support/json_schema/unaccompanied_minor.json
@@ -189,6 +189,9 @@
     "other_names": {
       "type": "array",
       "minItems": 1
+    },
+    "no_identification_reason": {
+      "type": "string"
     }
   },
   "$defs": {

--- a/spec/support/unaccompanied_minor_helpers.rb
+++ b/spec/support/unaccompanied_minor_helpers.rb
@@ -113,6 +113,30 @@ module UnaccompaniedMinorHelpers
     expect(page).to have_content(TASK_LIST_CONTENT)
   end
 
+  def uam_enter_sponsor_additional_details_no_ID_doc
+    expect(page).to have_content("Do you have any of these identity documents?")
+
+    choose("I don't have any of these")
+    click_button("Continue")
+
+    fill_in("unaccompanied_minor[no_identification_reason]", with: "Dog ate them all")
+    click_button("Continue")
+
+    expect(page).to have_content("Enter your date of birth")
+
+    uam_fill_in_date_of_birth(Time.zone.now - 21.years)
+
+    expect(page).to have_content("Enter your nationality")
+
+    select("Denmark", from: "unaccompanied-minor-nationality-field")
+    click_button("Continue")
+
+    expect(page).to have_content("Have you ever held any other nationalities?")
+    uam_choose_option("No")
+
+    expect(page).to have_content(TASK_LIST_CONTENT)
+  end
+
   def uam_enter_residential_address
     expect(page).to have_content("Enter the address where the child will be living in the UK")
     fill_in("Address line 1", with: "Address line 1")

--- a/spec/support/unaccompanied_minor_helpers.rb
+++ b/spec/support/unaccompanied_minor_helpers.rb
@@ -91,36 +91,26 @@ module UnaccompaniedMinorHelpers
     expect(page).to have_content(TASK_LIST_CONTENT)
   end
 
-  def uam_enter_sponsor_additional_details
-    expect(page).to have_content("Do you have any of these identity documents?")
+  def uam_sponsor_id_documents(option)
+    choose(option)
 
-    choose("Passport")
-    fill_in("Passport number", with: "123123123")
+    if option != "I don't have any of these"
+      fill_in("#{option} number", with: "123123123")
+    end
+
     click_button("Continue")
 
-    expect(page).to have_content("Enter your date of birth")
-
-    uam_fill_in_date_of_birth(Time.zone.now - 21.years)
-
-    expect(page).to have_content("Enter your nationality")
-
-    select("Denmark", from: "unaccompanied-minor-nationality-field")
-    click_button("Continue")
-
-    expect(page).to have_content("Have you ever held any other nationalities?")
-    uam_choose_option("No")
-
-    expect(page).to have_content(TASK_LIST_CONTENT)
+    if option == "I don't have any of these"
+      expect(page).to have_content("Can you prove your identity?")
+      fill_in("unaccompanied_minor[no_identification_reason]", with: "Dog ate them all")
+      click_button("Continue")
+    end
   end
 
-  def uam_enter_sponsor_additional_details_no_ID_doc
+  def uam_enter_sponsor_additional_details(option = "Passport")
     expect(page).to have_content("Do you have any of these identity documents?")
 
-    choose("I don't have any of these")
-    click_button("Continue")
-
-    fill_in("unaccompanied_minor[no_identification_reason]", with: "Dog ate them all")
-    click_button("Continue")
+    uam_sponsor_id_documents(option)
 
     expect(page).to have_content("Enter your date of birth")
 

--- a/spec/support/unaccompanied_minor_helpers.rb
+++ b/spec/support/unaccompanied_minor_helpers.rb
@@ -91,29 +91,28 @@ module UnaccompaniedMinorHelpers
     expect(page).to have_content(TASK_LIST_CONTENT)
   end
 
-  def uam_sponsor_identity_documents(option)
+  def uam_enter_sponsor_identity_documents(option)
     expect(page).to have_content("Do you have any of these identity documents?")
 
     choose(option)
 
-    if option != "I don't have any of these"
+    if option == "I don't have any of these"
+      click_button("Continue")
+      expect(page).to have_content("Can you prove your identity?")
+      fill_in("unaccompanied_minor[no_identification_reason]", with: "Dog ate them all")
+      click_button("Continue")
+    else
       fill_in("#{option} number", with: "123123123")
     end
 
     click_button("Continue")
-
-    if option == "I don't have any of these"
-      expect(page).to have_content("Can you prove your identity?")
-      fill_in("unaccompanied_minor[no_identification_reason]", with: "Dog ate them all")
-      click_button("Continue")
-    end
   end
 
   def uam_enter_sponsor_additional_details(
     id_option: "Passport",
     nationality: "Denmark", other_nationalities: []
   )
-    uam_sponsor_identity_documents(id_option)
+    uam_enter_sponsor_identity_documents(id_option)
 
     expect(page).to have_content("Enter your date of birth")
     uam_fill_in_date_of_birth(Time.zone.now - 21.years)

--- a/spec/support/unaccompanied_minor_helpers.rb
+++ b/spec/support/unaccompanied_minor_helpers.rb
@@ -142,7 +142,7 @@ module UnaccompaniedMinorHelpers
         expect(page).to have_content("Other nationalities")
 
         if (index + 1) < other_nationalities.length
-          click_button("Add another nationality")
+          click_link("Add another nationality")
         else
           click_link("Continue")
         end

--- a/spec/support/unaccompanied_minor_helpers.rb
+++ b/spec/support/unaccompanied_minor_helpers.rb
@@ -46,7 +46,6 @@ module UnaccompaniedMinorHelpers
   end
 
   def uam_enter_sponsor_name(given: "Spencer", family: "Sponsor", click_continue: true)
-    # click_link("Name") #### DONT LIKE THIS HERE NEIL
     expect(page).to have_content("Enter your name")
 
     fill_in_name(given, family, click_continue:)
@@ -64,6 +63,16 @@ module UnaccompaniedMinorHelpers
     if click_continue && option == "No"
       expect(page).to have_content(TASK_LIST_CONTENT)
     end
+  end
+
+  def uam_sponsor_known_by_another_name_2(option = "No", click_continue: true)
+    expect(page).to have_content(SPONSOR_OTHER_NAME_CONTENT)
+
+    uam_choose_option(option, click_continue:)
+    fill_in_name("Another", "Sponsor")
+    click_link("Continue")
+
+    expect(page).to have_content(TASK_LIST_CONTENT)
   end
 
   def uam_enter_sponsor_contact_details

--- a/spec/support/unaccompanied_minor_helpers.rb
+++ b/spec/support/unaccompanied_minor_helpers.rb
@@ -55,21 +55,21 @@ module UnaccompaniedMinorHelpers
     end
   end
 
-  def uam_sponsor_known_by_another_name(option = "No", click_continue: true)
+  def uam_enter_sponsor_not_known_by_another_name(click_continue: true)
     expect(page).to have_content(SPONSOR_OTHER_NAME_CONTENT)
 
-    uam_choose_option(option, click_continue:)
+    uam_choose_option("No", click_continue:)
 
-    if click_continue && option == "No"
+    if click_continue
       expect(page).to have_content(TASK_LIST_CONTENT)
     end
   end
 
-  def uam_sponsor_known_by_another_name_2(option = "No", click_continue: true)
+  def uam_enter_sponsor_other_name
     expect(page).to have_content(SPONSOR_OTHER_NAME_CONTENT)
 
-    uam_choose_option(option, click_continue:)
-    fill_in_name("Another", "Sponsor")
+    uam_choose_option("Yes")
+    fill_in_name("Another", "Sponsor", click_continue: true)
     click_link("Continue")
 
     expect(page).to have_content(TASK_LIST_CONTENT)

--- a/spec/system/confirm_page_spec.rb
+++ b/spec/system/confirm_page_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "Unaccompanied minor other adults", type: :system do
       check_sections_complete(0)
 
       uam_click_task_list_link("Additional details")
-      uam_enter_sponsor_additional_details
+      uam_enter_sponsor_additional_details_no_ID_doc
       check_sections_complete(1)
 
       uam_click_task_list_link("Address")
@@ -129,9 +129,12 @@ RSpec.describe "Unaccompanied minor other adults", type: :system do
       application = UnaccompaniedMinor.find_by_reference(app_ref)
       json = application.prepare_transfer
       json_object = JSON.parse(json)
+      puts json_object
 
       expect(json).to match_schema("unaccompanied_minor")
-      expect(json_object.keys).to include("other_names")
+      expect(json_object.keys).to include("other_names", "no_identification_reason")
     end
   end
+
+  
 end

--- a/spec/system/confirm_page_spec.rb
+++ b/spec/system/confirm_page_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "Unaccompanied minor other adults", type: :system do
       check_sections_complete(0)
 
       uam_click_task_list_link("Additional details")
-      uam_enter_sponsor_additional_details_no_ID_doc
+      uam_enter_sponsor_additional_details("I don't have any of these")
       check_sections_complete(1)
 
       uam_click_task_list_link("Address")
@@ -135,6 +135,4 @@ RSpec.describe "Unaccompanied minor other adults", type: :system do
       expect(json_object.keys).to include("other_names", "no_identification_reason")
     end
   end
-
-  
 end

--- a/spec/system/confirm_page_spec.rb
+++ b/spec/system/confirm_page_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Unaccompanied minor other adults", type: :system do
 
       uam_click_task_list_link("Name")
       uam_enter_sponsor_name
-      uam_sponsor_known_by_another_name
+      uam_enter_sponsor_not_known_by_another_name
       check_sections_complete(0)
 
       uam_click_task_list_link("Contact details")
@@ -77,7 +77,7 @@ RSpec.describe "Unaccompanied minor other adults", type: :system do
 
       uam_click_task_list_link("Name")
       uam_enter_sponsor_name
-      uam_sponsor_known_by_another_name_2("Yes")
+      uam_enter_sponsor_other_name
       check_sections_complete(0)
 
       uam_click_task_list_link("Contact details")
@@ -129,7 +129,6 @@ RSpec.describe "Unaccompanied minor other adults", type: :system do
       application = UnaccompaniedMinor.find_by_reference(app_ref)
       json = application.prepare_transfer
       json_object = JSON.parse(json)
-      puts json_object.keys
 
       expect(json).to match_schema("unaccompanied_minor")
       expect(json_object.keys).to include("other_names")

--- a/spec/system/confirm_page_spec.rb
+++ b/spec/system/confirm_page_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe "Unaccompanied minor other adults", type: :system do
 
     unless optional_keys.empty?
       json_object = JSON.parse(json)
-      puts json_object
+      # puts json_object
       expect(json_object.keys).to include(*optional_keys)
     end
   end

--- a/spec/system/confirm_page_spec.rb
+++ b/spec/system/confirm_page_spec.rb
@@ -128,8 +128,11 @@ RSpec.describe "Unaccompanied minor other adults", type: :system do
       app_ref = page.get_rack_session_key("app_reference")
       application = UnaccompaniedMinor.find_by_reference(app_ref)
       json = application.prepare_transfer
+      json_object = JSON.parse(json)
+      puts json_object.keys
 
       expect(json).to match_schema("unaccompanied_minor")
+      expect(json_object.keys).to include("other_names")
     end
   end
 end

--- a/spec/system/confirm_page_spec.rb
+++ b/spec/system/confirm_page_spec.rb
@@ -64,7 +64,9 @@ RSpec.describe "Unaccompanied minor other adults", type: :system do
     end
 
     it "whole end to end journey" do
-      optional_keys = %w[other_names no_identification_reason]
+      optional_keys = %w[other_names
+                         no_identification_reason
+                         other_nationalities]
 
       uam_enter_valid_complete_eligibility_section
       uam_start_page_to_task_list
@@ -79,7 +81,7 @@ RSpec.describe "Unaccompanied minor other adults", type: :system do
       check_sections_complete(0)
 
       uam_click_task_list_link("Additional details")
-      uam_enter_sponsor_additional_details("I don't have any of these")
+      uam_enter_sponsor_additional_details(id_option: "I don't have any of these", other_nationalities: %w[Albania])
       check_sections_complete(1)
 
       uam_click_task_list_link("Address")
@@ -128,7 +130,7 @@ RSpec.describe "Unaccompanied minor other adults", type: :system do
 
     unless optional_keys.empty?
       json_object = JSON.parse(json)
-      # puts json_object
+      puts json_object
       expect(json_object.keys).to include(*optional_keys)
     end
   end

--- a/spec/system/confirm_page_spec.rb
+++ b/spec/system/confirm_page_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "Unaccompanied minor other adults", type: :system do
       check_sections_complete(0)
 
       uam_click_task_list_link("Additional details")
-      uam_enter_sponsor_additional_details(id_option: "I don't have any of these", other_nationalities: %w[Albania])
+      uam_enter_sponsor_additional_details(id_option: "I don't have any of these", other_nationalities: %w[Albania Aruba])
       check_sections_complete(1)
 
       uam_click_task_list_link("Address")

--- a/spec/system/confirm_page_spec.rb
+++ b/spec/system/confirm_page_spec.rb
@@ -65,4 +65,71 @@ RSpec.describe "Unaccompanied minor other adults", type: :system do
       expect(json).to match_schema("unaccompanied_minor")
     end
   end
+
+  describe "user completes their application with MAX valid details" do
+    before do
+      driven_by(:rack_test_user_agent)
+    end
+
+    it "whole end to end journey" do
+      uam_enter_valid_complete_eligibility_section
+      uam_start_page_to_task_list
+
+      uam_click_task_list_link("Name")
+      uam_enter_sponsor_name
+      uam_sponsor_known_by_another_name_2("Yes")
+      check_sections_complete(0)
+
+      uam_click_task_list_link("Contact details")
+      uam_enter_sponsor_contact_details
+      check_sections_complete(0)
+
+      uam_click_task_list_link("Additional details")
+      uam_enter_sponsor_additional_details
+      check_sections_complete(1)
+
+      uam_click_task_list_link("Address")
+      uam_enter_residential_address
+      check_sections_complete(2)
+
+      uam_click_task_list_link("Child's personal details")
+      uam_enter_childs_personal_details
+      check_sections_complete(2)
+
+      uam_click_task_list_link("Upload UK consent form")
+      uam_upload_consent_forms
+      check_sections_complete(3)
+
+      uam_click_task_list_link("Confirm we can use your data")
+      uam_confirm_privacy_statement
+
+      uam_click_task_list_link("Confirm your eligibility")
+      uam_confirm_eligibilty
+      check_sections_complete(4)
+
+      uam_click_task_list_link("Check your answers and send")
+      uam_check_answers_and_submit
+
+      assert_transfer_json_is_valid
+
+      visit "/sponsor-a-child/confirm"
+      expect(page).to have_content("SPON-")
+
+      page.set_rack_session(app_reference: nil)
+      visit "/sponsor-a-child/confirm"
+      expect(page).to have_content("Use this service to apply for approval to sponsor a child fleeing Ukraine, who is not travelling with or joining their parent or legal guardian in the UK.")
+    end
+
+    def check_sections_complete(complete_sections)
+      expect(page).to have_content("You have completed #{complete_sections} of 4 sections.")
+    end
+
+    def assert_transfer_json_is_valid
+      app_ref = page.get_rack_session_key("app_reference")
+      application = UnaccompaniedMinor.find_by_reference(app_ref)
+      json = application.prepare_transfer
+
+      expect(json).to match_schema("unaccompanied_minor")
+    end
+  end
 end

--- a/spec/system/unaccompanied_minor_spec.rb
+++ b/spec/system/unaccompanied_minor_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe "Unaccompanied minor expression of interest", type: :system do
 
       fill_in_name("Jane", "Doe")
 
-      uam_sponsor_known_by_another_name
+      uam_enter_sponsor_not_known_by_another_name
     end
 
     it "complete child flow contact details section and save answers to the db" do


### PR DESCRIPTION
**Second pr** for [Jira ticket 991](https://digital.dclg.gov.uk/jira/browse/UKRSS-991)

This PR adds the functionality for the adapter to output Sponsor, Section one, optional additional details:
- other_names
- no_identification_reason
- other_nationalities

**To follow**
- Section 2 optional entries
- Section 3 optional entries

