### PR TITLE
Adding missing error boxes to steps 17,19,21,30

### DIFF
--- a/app/views/sponsor-a-child/steps/17.html.erb
+++ b/app/views/sponsor-a-child/steps/17.html.erb
@@ -3,9 +3,12 @@
 
     <a href="#" onclick="history.go(-1);return false;" class="govuk-back-link">Back</a>
 
+    <%= form_for @application, url: "/sponsor-a-child/steps/17", method: :post do |f| %>
+
+     <%= f.govuk_error_summary link_base_errors_to: :no_identification_reason %>
+
     <h1 class="govuk-heading-l"><%= t('no_identity_documents.full', scope: "unaccompanied_minor.questions")%></h1>
 
-    <%= form_for @application, url: "/sponsor-a-child/steps/17", method: :post do |f| %>
       <%= f.govuk_text_area :no_identification_reason,
         label: { text: "", hidden: true},
         hint: { text: t('no_identity_documents.hint', scope: "unaccompanied_minor.questions")},

--- a/app/views/sponsor-a-child/steps/19.html.erb
+++ b/app/views/sponsor-a-child/steps/19.html.erb
@@ -3,10 +3,12 @@
 
     <a href="#" onclick="history.go(-1);return false;" class="govuk-back-link">Back</a>
 
+    <%= form_for @application, url: "/sponsor-a-child/steps/19", method: :post do |f| %>
+    <%= f.govuk_error_summary link_base_errors_to: :nationality %>
+
     <h1 class="govuk-heading-l"><%= t('sponsor_nationality.full', scope: "unaccompanied_minor.questions")%></h1>
 
 
-    <%= form_for @application, url: "/sponsor-a-child/steps/19", method: :post do |f| %>
       <%= f.govuk_collection_select :nationality, @nationalities, :val, :name,
           label: {  text: t('sponsor_nationality.hint_html', scope: "unaccompanied_minor.questions")}
            %>

--- a/app/views/sponsor-a-child/steps/21.html.erb
+++ b/app/views/sponsor-a-child/steps/21.html.erb
@@ -2,10 +2,12 @@
   <div class="govuk-grid-column-two-thirds">
 
     <a href="#" onclick="history.go(-1);return false;" class="govuk-back-link">Back</a>
-    
-    <h1 class="govuk-heading-l"><%= t('sponsor_other_nationality.full', scope: "unaccompanied_minor.questions")%></h1>
 
     <%= form_for @application, url: "/sponsor-a-child/steps/21", method: :post do |f| %>
+    <%= f.govuk_error_summary link_base_errors_to: :other_nationality %>
+
+    <h1 class="govuk-heading-l"><%= t('sponsor_other_nationality.full', scope: "unaccompanied_minor.questions")%></h1>
+
       <%= f.govuk_collection_select :other_nationality, @nationalities, :val, :name,
           label: { text: "", hidden: true },
           hint: { text: t('sponsor_other_nationality.hint', scope: "unaccompanied_minor.questions")} %>

--- a/app/views/sponsor-a-child/steps/30.html.erb
+++ b/app/views/sponsor-a-child/steps/30.html.erb
@@ -2,10 +2,12 @@
   <div class="govuk-grid-column-two-thirds">
 
     <a href="#" onclick="history.go(-1);return false;" class="govuk-back-link">Back</a>
+    <%= form_for @application, url: "/sponsor-a-child/steps/30/#{params["key"]}", method: :post do |f| %>
+
+    <%= f.govuk_error_summary link_base_errors_to: :adult_nationality %>
 
     <h1 class="govuk-heading-l"><%= t('resident_nationality.full', scope: "unaccompanied_minor.questions")%></h1>
 
-    <%= form_for @application, url: "/sponsor-a-child/steps/30/#{params["key"]}", method: :post do |f| %>
 
       <%= f.govuk_collection_select :adult_nationality, @nationalities, :val, :name,
                                     label: { text: "", hidden: true },

--- a/spec/system/sponsor_additional_details_spec.rb
+++ b/spec/system/sponsor_additional_details_spec.rb
@@ -56,6 +56,17 @@ RSpec.describe "Sponsor additional details", type: :system do
       expect(page).to have_content("Error: Tell us how you can prove your identity, or why you cannot.")
     end
 
+    it "throws an error box on blank submission" do
+      navigate_to_additional_details
+      choose("I don't have any of these")
+      click_button("Continue")
+
+      expect(page).to have_content("Can you prove your identity?")
+
+      click_button("Continue")
+      expect(page).to have_content("There is a problem")
+    end
+
     it "validates other identity documents field on any submission" do
       navigate_to_additional_details
       choose("I don't have any of these")

--- a/spec/system/unaccompanied_minor_spec.rb
+++ b/spec/system/unaccompanied_minor_spec.rb
@@ -249,27 +249,7 @@ RSpec.describe "Unaccompanied minor expression of interest", type: :system do
     end
 
     it "complete child flow additional details section and save answers to the db" do
-      new_application = UnaccompaniedMinor.new
-      new_application.save!
-
-      page.set_rack_session(app_reference: new_application.reference)
-
-      visit "/sponsor-a-child/task-list"
-      expect(page).to have_content(task_list_content)
-
-      click_link("Additional details")
-      expect(page).to have_content("Do you have any of these identity documents?")
-
-      choose("Passport")
-      fill_in("Passport number", with: "123456789")
-      click_button("Continue")
-
-      fill_in("Day", with: "6")
-      fill_in("Month", with: "11")
-      fill_in("Year", with: "1987")
-      click_button("Continue")
-
-      expect(page).to have_content("Enter your nationality")
+      navigate_to_nationality
       select("Denmark", from: "unaccompanied-minor-nationality-field")
       click_button("Continue")
 
@@ -281,30 +261,19 @@ RSpec.describe "Unaccompanied minor expression of interest", type: :system do
     end
 
     it "does not allow for empty nationality to be selected" do
-      new_application = UnaccompaniedMinor.new
-      new_application.save!
+      navigate_to_nationality
 
-      page.set_rack_session(app_reference: new_application.reference)
-
-      visit "/sponsor-a-child/task-list"
-      expect(page).to have_content(task_list_content)
-
-      click_link("Additional details")
-      expect(page).to have_content("Do you have any of these identity documents?")
-
-      choose("Passport")
-      fill_in("Passport number", with: "123456789")
-      click_button("Continue")
-
-      fill_in("Day", with: "6")
-      fill_in("Month", with: "11")
-      fill_in("Year", with: "1987")
-      click_button("Continue")
-
-      expect(page).to have_content("Enter your nationality")
       click_button("Continue")
 
       expect(page).to have_content("Error: You must select a valid nationality")
+    end
+
+    it "shows an error box when no nationality is selected " do
+      navigate_to_nationality
+
+      click_button("Continue")
+
+      expect(page).to have_content("There is a problem")
     end
   end
 
@@ -950,5 +919,28 @@ RSpec.describe "Unaccompanied minor expression of interest", type: :system do
       choose("Refugee travel document")
       expect(page).to have_field("Refugee travel document number", with: "XYZ123987456")
     end
+  end
+
+  def navigate_to_nationality
+    new_application = UnaccompaniedMinor.new
+    new_application.save!
+
+    page.set_rack_session(app_reference: new_application.reference)
+
+    visit "/sponsor-a-child/task-list"
+    expect(page).to have_content(task_list_content)
+
+    click_link("Additional details")
+    expect(page).to have_content("Do you have any of these identity documents?")
+
+    choose("Passport")
+    fill_in("Passport number", with: "123456789")
+    click_button("Continue")
+
+    fill_in("Day", with: "6")
+    fill_in("Month", with: "11")
+    fill_in("Year", with: "1987")
+    click_button("Continue")
+    expect(page).to have_content("Enter your nationality")
   end
 end

--- a/spec/system/unaccompanied_minor_sponsor_other_nationalities_spec.rb
+++ b/spec/system/unaccompanied_minor_sponsor_other_nationalities_spec.rb
@@ -66,6 +66,30 @@ RSpec.describe "Unaccompanied minor sponsor other nationalities", type: :system 
       expect(page).to have_content(task_list_content)
     end
 
+    describe "UAM other nationailties select other nationality form" do
+      it "does not allow for empty other nationality to be selected " do
+        task_list_to_other_nationalities_question
+
+        choose("Yes")
+        click_button("Continue")
+
+        click_button("Continue")
+
+        expect(page).to have_content("Error: You must select a valid nationality")
+      end
+
+      it "shows an error box when no nationality is selected " do
+        task_list_to_other_nationalities_question
+
+        choose("Yes")
+        click_button("Continue")
+
+        click_button("Continue")
+
+        expect(page).to have_content("There is a problem")
+      end
+    end
+
     def task_list_to_other_nationalities_question
       visit "/sponsor-a-child/task-list"
       expect(page).to have_content(task_list_content)


### PR DESCRIPTION
PR [1070](https://digital.dclg.gov.uk/jira/browse/UKRSS-1070)

Added an error box to the pages which currently did not have one when there was an error.  Also added test checking if an error box showed up on each page when triggered.  Added unit tests and a method added to avoid some repeated code.  
