### PR TITLE
 1009: fix cookie overflow  

### DIFF
--- a/app/controllers/token_based_resume_controller.rb
+++ b/app/controllers/token_based_resume_controller.rb
@@ -102,7 +102,6 @@ class TokenBasedResumeController < ApplicationController
             # the application exists, store in the session and let them resume
             @application = @applicationtoken.unaccompanied_minor
             session[:app_reference] = @application.reference
-            session[:unaccompanied_minor] = @application.as_json
             render "sponsor-a-child/task_list"
           else
             # no application was found with this token
@@ -131,7 +130,6 @@ class TokenBasedResumeController < ApplicationController
       selected_application = request.POST["reference"]
       @application = UnaccompaniedMinor.find_by(reference: selected_application)
       session[:app_reference] = selected_application
-      session[:unaccompanied_minor] = @application.as_json
       render "sponsor-a-child/task_list"
     else
       flash[:error] = "No applications found"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       DB_PASSWORD: password
       VCAP_SERVICES: '{"redis":[{"instance_name":"ukraine-sponsor-resettlement-development-redis","credentials":{"uri":"redis://redis"}}],"aws-s3-bucket":[{"instance_name":"ukraine-sponsor-resettlement-development-s3","credentials":{"aws_access_key_id":"access-key-id","aws_secret_access_key":"secret-access-key","aws_region":"eu-west-2","bucket_name":"upload-bucket"}}]}'
       BASIC_AUTH_PASS: password
+      UAM_FEATURE_SAVE_AND_RETURN_ACTIVE: true
     ports:
       - 8080:8080
 

--- a/spec/system/token_based_resume_controller_spec.rb
+++ b/spec/system/token_based_resume_controller_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe TokenBasedResumeController, type: :system do
       page.driver.post "/sponsor-a-child/resume-application", params
 
       expect(page).to have_content(task_list_content)
-      visit "/sponsor-a-child/steps/10"
+      uam_click_task_list_link("Name")
       expect(page).to have_content(given_name)
     end
   end

--- a/spec/system/token_based_resume_controller_spec.rb
+++ b/spec/system/token_based_resume_controller_spec.rb
@@ -188,6 +188,8 @@ RSpec.describe TokenBasedResumeController, type: :system do
       page.driver.post "/sponsor-a-child/resume-application", params
 
       expect(page).to have_content(task_list_content)
+      visit "/sponsor-a-child/steps/10"
+      expect(page).to have_content("given_name")
     end
   end
 end

--- a/spec/system/token_based_resume_controller_spec.rb
+++ b/spec/system/token_based_resume_controller_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe TokenBasedResumeController, type: :system do
 
       expect(page).to have_content(task_list_content)
       visit "/sponsor-a-child/steps/10"
-      expect(page).to have_content("given_name")
+      expect(page).to have_content(given_name)
     end
   end
 end


### PR DESCRIPTION
[UKRSS-1009] (https://digital.dclg.gov.uk/jira/browse/UKRSS-1009)
From Sentry errors: https://sentry.io/share/issue/f9ae20faf39341b99424465e827bd6e4/
Removes serialization of UAM data to session.
Adds test for form data restoration when resuming application.