### PR TITLE
moving the inset to be an inset and correct label added

### DIFF
--- a/app/views/sponsor-a-child/steps/30.html.erb
+++ b/app/views/sponsor-a-child/steps/30.html.erb
@@ -9,9 +9,12 @@
     <h1 class="govuk-heading-l"><%= t('resident_nationality.full', scope: "unaccompanied_minor.questions")%></h1>
 
 
+    <div class="govuk-inset-text">
+      <%= "#{@adult["given_name"]} #{@adult["family_name"]}" %>
+    </div>
+
       <%= f.govuk_collection_select :adult_nationality, @nationalities, :val, :name,
-                                    label: { text: "", hidden: true },
-                                    hint: { text: t('resident_nationality.hint_html', :name => "#{@adult["given_name"]} #{@adult["family_name"]}", scope: "unaccompanied_minor.questions")}
+                                    label: { text: "Select their country of nationality" }
       %>
 
       <div class="govuk-button-group">


### PR DESCRIPTION
PR [1071](https://digital.dclg.gov.uk/jira/browse/UKRSS-1071?filter=-1)

Step 30 is missing a label for the text box and the inset text for the Other Adult Name is a hint text on the box meaning the error line extends into it.

Before

<img width="786" alt="Screenshot 2022-10-03 at 12 35 29" src="https://user-images.githubusercontent.com/11315500/194577580-f2869693-94f5-43cd-b4b4-6a7c37a2620a.png">

After

<img width="585" alt="Screenshot 2022-10-07 at 15 30 40" src="https://user-images.githubusercontent.com/11315500/194578163-3b1b4101-49e0-494d-ba10-160960ae086b.png">


