### PR TITLE
1076 Token based resume no application present 

### DIFF
--- a/app/controllers/token_based_resume_controller.rb
+++ b/app/controllers/token_based_resume_controller.rb
@@ -28,7 +28,9 @@ class TokenBasedResumeController < ApplicationController
 
   def save_return
     @application = UnaccompaniedMinor.find_by_reference(session[:app_reference])
-    if @application.email.blank?
+    if @application.nil?
+      redirect_to "/sponsor-a-child/start"
+    elsif @application.email.blank?
       # email not provided
       redirect_to "/sponsor-a-child/steps/14?save=1"
     elsif @application.phone_number.blank?

--- a/spec/system/token_based_resume_controller_spec.rb
+++ b/spec/system/token_based_resume_controller_spec.rb
@@ -198,6 +198,4 @@ RSpec.describe TokenBasedResumeController, type: :system do
       expect(page).to have_content(given_name)
     end
   end
-
-  describe ""
 end

--- a/spec/system/token_based_resume_controller_spec.rb
+++ b/spec/system/token_based_resume_controller_spec.rb
@@ -128,6 +128,12 @@ RSpec.describe TokenBasedResumeController, type: :system do
       expect(page).to have_content(I18n.t("phone_number.full", scope: "unaccompanied_minor.questions"))
     end
 
+    it "redirects to start page if no application is present" do
+      visit "/sponsor-a-child/save-and-return"
+
+      expect(page).to have_content("Apply to provide a safe home for a child from Ukraine")
+    end
+
     it "allows the user to resume an application if the correct email is provided" do
       page.set_rack_session(app_reference: uam.reference)
 
@@ -192,4 +198,6 @@ RSpec.describe TokenBasedResumeController, type: :system do
       expect(page).to have_content(given_name)
     end
   end
+
+  describe ""
 end


### PR DESCRIPTION
PR for [Jira-1076](https://digital.dclg.gov.uk/jira/browse/UKRSS-1076)

Added guard clause to token based resume for if no application present and save and return is visited. Should fix sentry error https://sentry.io/organizations/dluhc-ulss/issues/3644538887/?environment=production&project=6260319

Now redirects to "sponsor-a-child/start"