### PR TITLE
upgrade actions/checkout@v2 => v3

### DIFF
--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -182,7 +182,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Cloud Foundry CLI
         run: |
@@ -303,7 +303,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Cloud Foundry CLI
         run: |


### PR DESCRIPTION
Github actions pipeline has started (11th October) to emit warnings.

There appear to be 2 actions causing these:

1. `actions/checkout@v2`, **this PR** covers upgrading to `v3` and significantly reduces the warnings.
1. `ruby/setup-ruby@v1` - on [checking](https://github.com/ruby/setup-ruby) we are using the latest version. I suggest we wait a little while before deciding on further action. I suspect it will get updated as it is managed by the `ruby` org.
