### PR TITLE
adds guard clause for token based controller display method 

### DIFF
--- a/app/controllers/token_based_resume_controller.rb
+++ b/app/controllers/token_based_resume_controller.rb
@@ -13,13 +13,17 @@ class TokenBasedResumeController < ApplicationController
   def display
     @abstractresumetoken = AbstractResumeToken.new(magic_link: params[:uuid])
     @application_reference = ApplicationToken.find_by(magic_link: params[:uuid])
+    if @application_reference.present?
 
-    if Time.zone.now.utc > @application_reference.expires_at
-      flash[:error] = "This code has expired, please request a new one"
+      if Time.zone.now.utc > @application_reference.expires_at
+        flash[:error] = "This code has expired, please request a new one"
+      else
+        send_token
+      end
+      render "token-based-resume/session_resume_form"
     else
-      send_token
+      render "/sponsor-a-child/start"
     end
-    render "token-based-resume/session_resume_form"
   end
 
   def save_return_confirm

--- a/spec/system/token_based_resume_controller_spec.rb
+++ b/spec/system/token_based_resume_controller_spec.rb
@@ -173,4 +173,12 @@ RSpec.describe TokenBasedResumeController, type: :system do
       { abstract_resume_token: { token: app_token.token }, uuid: app_token.magic_link }
     end
   end
+
+  describe "user tries to return without an application present" do
+    it "redirects them to the start page" do
+      visit "/sponsor-a-child/resume-application"
+
+      expect(page).to have_content("Use this service to apply for approval to sponsor a child fleeing Ukraine, who is not travelling with or joining their parent or legal guardian in the UK.")
+    end
+  end
 end


### PR DESCRIPTION
Redirects to start page if application isn't found on resume application page 