### PR TITLE
Fixes a naming error that causes deployment issues

### DIFF
--- a/app/controllers/eoi_controller.rb
+++ b/app/controllers/eoi_controller.rb
@@ -89,7 +89,7 @@ class EoiController < ApplicationController
       session[:app_reference] = @application.reference
       session[:eoi] = {}
 
-      SendExpressionOfInterestUpdateJob.perform_later(@application.id)
+      SendEoiUpdateJob.perform_later(@application.id)
       GovNotifyMailer.send_expression_of_interest_confirmation_email(@application).deliver_later
       redirect_to "/expression-of-interest/confirm"
     else

--- a/app/jobs/send_eoi_update_job.rb
+++ b/app/jobs/send_eoi_update_job.rb
@@ -1,4 +1,4 @@
-class SendExpressionOfInterestUpdateJob < ApplicationJob
+class SendEoiUpdateJob < ApplicationJob
   queue_as :default
 
   def perform(id)


### PR DESCRIPTION
Error in the logs

```
 2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/zeitwerk-2.6.1/lib/zeitwerk/loader/callbacks.rb:25:in `on_file_autoloaded': expected file /home/vcap/app/app/jobs/send_eoi_update_job.rb to define constant SendEoiUpdateJob, but didn't (Zeitwerk::NameError)
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR raise Zeitwerk::NameError.new("expected file #{file} to define constant #{cpath}, but didn't", cref.last)
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR ^^^^^
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/zeitwerk-2.6.1/lib/zeitwerk/kernel.rb:28:in `require'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/zeitwerk-2.6.1/lib/zeitwerk/loader/helpers.rb:127:in `const_get'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/zeitwerk-2.6.1/lib/zeitwerk/loader/helpers.rb:127:in `cget'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/zeitwerk-2.6.1/lib/zeitwerk/loader.rb:239:in `block (2 levels) in eager_load'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/zeitwerk-2.6.1/lib/zeitwerk/loader/helpers.rb:41:in `block in ls'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/zeitwerk-2.6.1/lib/zeitwerk/loader/helpers.rb:27:in `each'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/zeitwerk-2.6.1/lib/zeitwerk/loader/helpers.rb:27:in `ls'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/zeitwerk-2.6.1/lib/zeitwerk/loader.rb:234:in `block in eager_load'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/zeitwerk-2.6.1/lib/zeitwerk/loader.rb:219:in `synchronize'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/zeitwerk-2.6.1/lib/zeitwerk/loader.rb:219:in `eager_load'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/zeitwerk-2.6.1/lib/zeitwerk/loader.rb:318:in `each'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/zeitwerk-2.6.1/lib/zeitwerk/loader.rb:318:in `eager_load_all'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/railties-7.0.4/lib/rails/application/finisher.rb:74:in `block in <module:Finisher>'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/railties-7.0.4/lib/rails/initializable.rb:32:in `instance_exec'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/railties-7.0.4/lib/rails/initializable.rb:32:in `run'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/railties-7.0.4/lib/rails/initializable.rb:61:in `block in run_initializers'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/ruby/lib/ruby/3.1.0/tsort.rb:228:in `block in tsort_each'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/ruby/lib/ruby/3.1.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/ruby/lib/ruby/3.1.0/tsort.rb:431:in `each_strongly_connected_component_from'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/ruby/lib/ruby/3.1.0/tsort.rb:349:in `block in each_strongly_connected_component'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/ruby/lib/ruby/3.1.0/tsort.rb:347:in `each'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/ruby/lib/ruby/3.1.0/tsort.rb:347:in `call'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/ruby/lib/ruby/3.1.0/tsort.rb:347:in `each_strongly_connected_component'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/ruby/lib/ruby/3.1.0/tsort.rb:226:in `tsort_each'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/ruby/lib/ruby/3.1.0/tsort.rb:205:in `tsort_each'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/railties-7.0.4/lib/rails/initializable.rb:60:in `run_initializers'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/railties-7.0.4/lib/rails/application.rb:372:in `initialize!'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/app/config/environment.rb:5:in `<main>'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from config.ru:3:in `require_relative'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from config.ru:3:in `block in <main>'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/rack-2.2.4/lib/rack/builder.rb:116:in `eval'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/rack-2.2.4/lib/rack/builder.rb:116:in `new_from_string'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/rack-2.2.4/lib/rack/builder.rb:105:in `load_file'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/rack-2.2.4/lib/rack/builder.rb:66:in `parse_file'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/rack-2.2.4/lib/rack/server.rb:349:in `build_app_and_options_from_config'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/rack-2.2.4/lib/rack/server.rb:249:in `app'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/rack-2.2.4/lib/rack/server.rb:422:in `wrapped_app'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/rack-2.2.4/lib/rack/server.rb:312:in `block in start'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/rack-2.2.4/lib/rack/server.rb:379:in `handle_profiling'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/rack-2.2.4/lib/rack/server.rb:311:in `start'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:38:in `start'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:143:in `block in perform'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from <internal:kernel>:90:in `tap'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:134:in `perform'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/railties-7.0.4/lib/rails/command/base.rb:87:in `perform'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/railties-7.0.4/lib/rails/command.rb:48:in `invoke'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/railties-7.0.4/lib/rails/commands.rb:18:in `<main>'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from /home/vcap/deps/0/vendor_bundle/ruby/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
   2022-10-19T14:31:50.79+0100 [APP/PROC/WEB/0] ERR from bin/rails:4:in `<main>'
```