### PR TITLE
correcting path name for google analytics

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ private
     if request.fullpath.include?("child") && ENV["UAM_GA_TRACKING_CODE"].present?
       GA.tracker = ENV.fetch("UAM_GA_TRACKING_CODE")
     end
-    if request.fullpath.include?("individual") && ENV["EOI_GA_TRACKING_CODE"].present?
+    if request.fullpath.include?("expression") && ENV["EOI_GA_TRACKING_CODE"].present?
       GA.tracker = ENV.fetch("EOI_GA_TRACKING_CODE")
     end
   end


### PR DESCRIPTION
Changing the GA path name to be included on the expression-of-interest path as opposed the deprecated individual path 