### PR TITLE
adding validation for no option step 9

### DIFF
--- a/app/controllers/eoi_controller.rb
+++ b/app/controllers/eoi_controller.rb
@@ -64,6 +64,9 @@ class EoiController < ApplicationController
     @application.assign_attributes(application_params)
 
     if current_stage == 9 # hosting_start_date
+      if params["expression_of_interest"]["host_as_soon_as_possible"].blank?
+        @application.errors.add(:host_as_soon_as_possible, I18n.t(:choose_option, scope: :error))
+      end
       if params["expression_of_interest"]["host_as_soon_as_possible"] != "true"
         begin
           hosting_start_date = Date.new(params["expression_of_interest"]["hosting_start_date(1i)"].to_i, params["expression_of_interest"]["hosting_start_date(2i)"].to_i, params["expression_of_interest"]["hosting_start_date(3i)"].to_i)


### PR DESCRIPTION
Adding validation for step 9 - if there is no option selected on the initial radio boxes and you press continue it will ask you to select an option.