### PR TITLE
fixing regression issues caused by querystring

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,7 +44,7 @@ private
       @cookie_accepted = session[:cookies_accepted].casecmp("true").zero?
       @cookie_banner_form_step = 2
     end
-    if params[:cookies_accepted].present? && params[:c_m_h].present?
+    if params[:c_m_h].present?
       session[:cookie_message_hidden] = params[:c_m_h]
     end
     if session[:cookie_message_hidden].present?

--- a/app/views/shared/_cookie_banner.html.erb
+++ b/app/views/shared/_cookie_banner.html.erb
@@ -1,4 +1,3 @@
-<form method="POST">
 
     <div  class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on Homes for Ukraine">
           <% if !@cookie_accepted && @cookie_banner_form_step == 1  %>  
@@ -19,7 +18,6 @@
             <div id="cookie-banner__button-group" class="govuk-button-group">
             <%= link_to "Accept analytics cookies", request.original_url + '?cookies_accepted=true',  class: 'govuk-button cookie-button', method: :post, value:"accept"  %>
             <%= link_to "Reject analytics cookies", request.original_url + '?cookies_accepted=false',  class: 'govuk-button cookie-button', method: :post, value:"reject"  %>
-
             
             </div>
         </div>
@@ -39,11 +37,10 @@
 
       <div class="govuk-button-group">
 
-      <%= link_to "Hide cookie message", request.original_url + '&c_m_h=true',  class: 'govuk-button',method: :post  %>
+      <%= link_to "Hide cookie message", request.original_url + '?&c_m_h=true',  class: 'govuk-button',method: :post  %>
       </div>
     </div>
      <% end %>  
 
- </form>
 
  


### PR DESCRIPTION
Had a regression error caused when the user had accepted or rejected cookies but not hidden the form.  Caused a 404 error which is now fixed.