### PR TITLE
adding error summary boxes to self assessment flow

### DIFF
--- a/app/javascript/packs/self_assessment_navigation.js
+++ b/app/javascript/packs/self_assessment_navigation.js
@@ -7,8 +7,8 @@
           selfAssesmentContinueButton.addEventListener('click', function() {
               var elements = document.getElementsByName('assessment-buttons');
               var formGroup = document.querySelector('.govuk-form-group');
-              var errorMessage = document.querySelector('.govuk-error-message')
-
+              var errorMessage = document.querySelector('.govuk-error-message');
+              var errorSummaryBox = document.querySelector('.govuk-error-summary');
               var selectedOption;
   
               if(!formGroup) {
@@ -25,10 +25,13 @@
                   window.location.href = selectedOption;
                   formGroup.classList.remove('govuk-form-group--error')
                   errorMessage.style.display = 'none';
+                  errorSummaryBox.style.display = 'none'
+
               
               } else {
                   formGroup.classList.add('govuk-form-group--error')
                   errorMessage.style.display = 'block';
+                  errorSummaryBox.style.display = 'block'
               }
             
             })

--- a/app/views/eoi/steps/can_you_commit.html.erb
+++ b/app/views/eoi/steps/can_you_commit.html.erb
@@ -1,6 +1,20 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
+    <div  style="display:none" class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary">
+      <h2 class="govuk-error-summary__title" id="error-summary-title">
+        There is a problem
+      </h2>
+      <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list">
+          <li>
+            <a href="#selectoption">You must select an option to continue</a>
+          </li>
+
+        </ul>
+      </div>
+    </div>
+
       <h1 class="govuk-heading-l">
         Can you commit to hosting for at least 6 months?
       </h1>

--- a/app/views/eoi/steps/challenges.html.erb
+++ b/app/views/eoi/steps/challenges.html.erb
@@ -1,6 +1,20 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
+    <div style="display:none" class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary">
+      <h2 class="govuk-error-summary__title" id="error-summary-title">
+        There is a problem
+      </h2>
+      <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list">
+          <li>
+            <a href="#selectoption">You must select an option to continue</a>
+          </li>
+
+        </ul>
+      </div>
+    </div>
+
       <h1 class="govuk-heading-l">
         Important things to consider
       </h1>

--- a/app/views/eoi/steps/is_your_property_suitable.html.erb
+++ b/app/views/eoi/steps/is_your_property_suitable.html.erb
@@ -1,6 +1,20 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
+    <div style="display:none" class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary">
+      <h2 class="govuk-error-summary__title" id="error-summary-title">
+        There is a problem
+      </h2>
+      <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list">
+          <li>
+            <a href="#selectoption">You must select an option to continue</a>
+          </li>
+
+        </ul>
+      </div>
+    </div>
+
       <h1 class="govuk-heading-l">
         Check if your property is suitable for hosting
       </h1>


### PR DESCRIPTION
PR [https://digital.dclg.gov.uk/jira/browse/UKRSS-1214](1214)

Adding error summary boxes to the self assessment user flow.   Summary boxes go above H1 and on all self assessment boxes where the user needs to select an option.

Works by toggling display setting to display block.

Before

<img width="723" alt="Screenshot 2022-11-09 at 13 58 40" src="https://user-images.githubusercontent.com/11315500/200849610-9d6b1a14-d6cb-40d4-b734-78bfcb751eee.png">

After

<img width="713" alt="Screenshot 2022-11-09 at 14 00 24" src="https://user-images.githubusercontent.com/11315500/200849921-fd36734e-66a5-4f98-b0a8-50554fd34c0d.png">
