### PR TITLE
lower to 4 web and 2 sidekiq instances

### DIFF
--- a/policy.json
+++ b/policy.json
@@ -1,5 +1,5 @@
 {
-  "instance_min_count": 8,
+  "instance_min_count": 4,
   "instance_max_count": 32,
   "scaling_rules": [
     {

--- a/web-manifest.yml
+++ b/web-manifest.yml
@@ -33,7 +33,7 @@ applications:
     env:
       RAILS_ENV: production
       INSTANCE_NAME: ukraine-sponsor-resettlement-production
-    instances: 8
+    instances: 4
     memory: 512M
     services:
       - ukraine-sponsor-resettlement-production-postgres

--- a/worker-manifest.yml
+++ b/worker-manifest.yml
@@ -21,7 +21,7 @@ applications:
     <<: *defaults
     env:
       RAILS_ENV: production
-    instances: 4
+    instances: 2
     services:
       - ukraine-sponsor-resettlement-production-postgres
       - ukraine-sponsor-resettlement-production-redis


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/UKRSS-1667

09:45 Stéphane Meny
Hi all :wave::skin-tone-3: Lee ask me to do a quick estimation of how much an AWS equivalent of what is on PaaS (for HfU EOI form) would cost. I noticed we still run the main web server on 8 instances and 4 sidekiq instances. Do we still need that much compute power?
(based on the historical usage on Grafana we could determine if the utilisation is appropriate, not sure I still have access to the dashboard I still do so checking) (edited)
Except for a quick memory spike on an instance, it is clear the resources are under utilised, we could divide the resources by half.