### PR TITLE
attach scaling policy to autoscaler on deploy to prod

### DIFF
--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -351,7 +351,7 @@ jobs:
           cf set-env $APP_NAME UAM_FOUNDRY_ATTACHMENT_ASSIGN_API_URL $UAM_FOUNDRY_ATTACHMENT_ASSIGN_API_URL
           cf set-env $APP_NAME UAM_GA_TRACKING_CODE $UAM_GA_TRACKING_CODE
           cf push -f web-manifest.yml $APP_NAME --strategy rolling --no-wait
-
+          cf attach-autoscaling-policy $APP_NAME policy.json
       - name: Deploy Sidekiq
         env:
           APP_NAME: ukraine-sponsor-resettlement-production-sidekiq


### PR DESCRIPTION
Autoscaling policy should be attached to the auto scaler on deploy so that changes can be applied as part of deploy process.