### PR TITLE
[accessibility fixes] DAC NON DESCRIPTIVE LABEL 01 for UAM and EOI

### DIFF
--- a/app/views/eoi/steps/different_address.html.erb
+++ b/app/views/eoi/steps/different_address.html.erb
@@ -21,10 +21,10 @@
         </legend>
 
       <%= f.govuk_collection_radio_buttons :different_address,
-          @application.different_address_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "expression_of_interest.different_address")) },
+          @application.different_address_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "expression_of_interest.questions.different_address")) },
           :id,
           :name,
-          legend: { text: t('different_address.full', scope: "expression_of_interest.questions"), hidden:true }
+          legend: { text: t('different_address.full', scope: "expression_of_interest.questions.different_address"), hidden:true }
       %>
       </fieldset>
       <%= f.govuk_submit t('continue') %>

--- a/app/views/eoi/steps/more_properties.html.erb
+++ b/app/views/eoi/steps/more_properties.html.erb
@@ -20,7 +20,7 @@
         </legend>
 
       <%= f.govuk_collection_radio_buttons :more_properties,
-          @application.more_properties_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "expression_of_interest.more_properties")) },
+          @application.more_properties_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "expression_of_interest.questions.more_properties")) },
           :id,
           :name,
           legend: { text: t('more_properties.full', scope: "additional_info.questions"), hidden:true },

--- a/app/views/eoi/steps/user_research.html.erb
+++ b/app/views/eoi/steps/user_research.html.erb
@@ -19,7 +19,7 @@
         </legend>
 
       <%= f.govuk_collection_radio_buttons :user_research,
-          @application.user_research_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "expression_of_interest.user_research")) },
+          @application.user_research_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "expression_of_interest.questions.user_research")) },
           :id,
           :name,
           legend: { text: t('user_research.full', scope: "additional_info.questions"), hidden:true},

--- a/app/views/sponsor-a-child/steps/1.html.erb
+++ b/app/views/sponsor-a-child/steps/1.html.erb
@@ -13,7 +13,7 @@
           <h1 class="govuk-heading-l"><%= t('sponsored_children_age.full', scope: "unaccompanied_minor.questions")%></h1>
         </legend>
       <%= f.govuk_collection_radio_buttons :is_under_18,
-                                           @application.eligibility_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.different_address")) },
+                                           @application.eligibility_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.questions.sponsored_children_age")) },
                                            :id,
                                            :name,
                                            legend: { text: "", hidden: true }

--- a/app/views/sponsor-a-child/steps/2.html.erb
+++ b/app/views/sponsor-a-child/steps/2.html.erb
@@ -12,7 +12,7 @@
           <h1 class="govuk-heading-l"><%= t('sponsored_children_living_december.full', scope: "unaccompanied_minor.questions")%></h1>
         </legend>
       <%= f.govuk_collection_radio_buttons :is_living_december,
-                                           @application.eligibility_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.different_address")) },
+                                           @application.eligibility_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.questions.sponsored_children_living_december")) },
                                            :id,
                                            :name,
                                            legend: { text: t('sponsored_children_living_december.full', scope: "unaccompanied_minor.questions"), hidden: true },

--- a/app/views/sponsor-a-child/steps/24.html.erb
+++ b/app/views/sponsor-a-child/steps/24.html.erb
@@ -10,15 +10,15 @@
 
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-    <h1 class="gem-c-title__text govuk-heading-l">
-      Will you (the sponsor) be living at this address?
-    </h1>
+          <h1 class="gem-c-title__text govuk-heading-l">
+            Will you (the sponsor) be living at this address?
+          </h1>
         </legend>
 
     <div class="govuk-inset-text"><%= @application.formatted_address? %></div>
 
       <%= f.govuk_collection_radio_buttons :different_address,
-          @application.different_address_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.different_address")) },
+          @application.different_address_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "yes_no_types")) },
           :id,
           :name,
           legend: { text: t('different_address.full', scope: "unaccompanied_minor.questions"), hidden: true },

--- a/app/views/sponsor-a-child/steps/25.html.erb
+++ b/app/views/sponsor-a-child/steps/25.html.erb
@@ -33,7 +33,7 @@
             </details>
 
       <%= f.govuk_collection_radio_buttons :other_adults_address,
-          @application.other_adults_address_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.different_address")) },
+          @application.other_adults_address_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.questions.different_address")) },
           :id,
           :name,
           legend: { text: "", hidden: true }

--- a/app/views/sponsor-a-child/steps/3.html.erb
+++ b/app/views/sponsor-a-child/steps/3.html.erb
@@ -12,7 +12,7 @@
           <h1 class="govuk-heading-l"><%= t('sponsored_children_december_birth.full', scope: "unaccompanied_minor.questions")%></h1>
         </legend>
       <%= f.govuk_collection_radio_buttons :is_born_after_december,
-                                           @application.eligibility_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.different_address")) },
+                                           @application.eligibility_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.questions.sponsored_children_legal_guardian_travelling")) },
                                            :id,
                                            :name,
                                            legend: { text: t('sponsored_children_december_birth.full', scope: "unaccompanied_minor.questions"), hidden: true }

--- a/app/views/sponsor-a-child/steps/4.html.erb
+++ b/app/views/sponsor-a-child/steps/4.html.erb
@@ -14,7 +14,7 @@
           <h1 class="govuk-heading-l"><%= t('sponsored_children_legal_guardian_travelling.full', scope: "unaccompanied_minor.questions")%></h1>
         </legend>
       <%= f.govuk_collection_radio_buttons :is_unaccompanied,
-                                           @application.eligibility_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.different_address")) },
+                                           @application.eligibility_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.questions.sponsored_children_legal_guardian_travelling")) },
                                            :id,
                                            :name,
                                            legend: { text: t('sponsored_children_legal_guardian_travelling.full', scope: "unaccompanied_minor.questions"), hidden: true },

--- a/app/views/sponsor-a-child/steps/5.html.erb
+++ b/app/views/sponsor-a-child/steps/5.html.erb
@@ -12,7 +12,7 @@
           <h1 class="govuk-heading-l"><%= t('sponsored_children_legal_guardian_consent.full', scope: "unaccompanied_minor.questions")%></h1>
         </legend>
       <%= f.govuk_collection_radio_buttons :is_consent,
-                                           @application.eligibility_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.different_address")) },
+                                           @application.eligibility_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.questions.sponsored_children_legal_guardian_consent")) },
                                            :id,
                                            :name,
                                            legend: { text: t('sponsored_children_legal_guardian_consent.full', scope: "unaccompanied_minor.questions"), hidden: true },

--- a/app/views/sponsor-a-child/steps/6.html.erb
+++ b/app/views/sponsor-a-child/steps/6.html.erb
@@ -23,7 +23,7 @@
         </details>
 
       <%= f.govuk_collection_radio_buttons :is_committed,
-                                           @application.eligibility_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.different_address")) },
+                                           @application.eligibility_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.questions.sponsor_commitment")) },
                                            :id,
                                            :name,
                                            legend: { text: "", hidden: true }

--- a/app/views/sponsor-a-child/steps/7.html.erb
+++ b/app/views/sponsor-a-child/steps/7.html.erb
@@ -23,7 +23,7 @@
         </details>
 
       <%= f.govuk_collection_radio_buttons :is_permitted,
-                                           @application.eligibility_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.different_address")) },
+                                           @application.eligibility_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.questions.sponsor_right_to_live_in_uk")) },
                                            :id,
                                            :name,
                                            legend: { text: "", hidden: true }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,8 +31,8 @@
 
 en:
   yes_no_types:
-    yes: "Yes"
-    no: "No"
+    "yes": "Yes"
+    "no": "No"
   individual:
     questions:
       family_type:
@@ -152,6 +152,8 @@ en:
       step_free:
         short: Step-free access
         full: Does the property, or any of the properties, have step-free access?
+        "yes": "Yes"
+        "no": "No"
       single_room_count:
         short: Single bedrooms available
         full: How many single bedrooms do you have available in the property you have specified?
@@ -194,6 +196,8 @@ en:
       different_address:
         short: Different address
         full: Is the property you’re offering at a different address to your home?
+        "yes": "Yes"
+        "no": "No"
       more_properties:
         short: More properties
         full: Are you offering any more properties?
@@ -218,7 +222,8 @@ en:
         short: User research
         full: Would you like to take part in research to help us improve the Homes for Ukraine service?
         hint: This could involve completing a survey or taking part in a video call with a user research team. If you choose ‘Yes’, you’re agreeing to be contacted using the email address or telephone number you provided in this form.
-
+        "yes": "Yes"
+        "no": "No"
       agree_privacy_statement:
         short: Privacy statement
         full: Confirm you have read the privacy statement and agree that the information you have provided in this form can be used for the Homes for Ukraine scheme
@@ -385,12 +390,6 @@ en:
       from_6_to_9_months: From 6 to 9 months
       from_10_to_12_months: From 10 to 12 months
       more_than_12_months: More than 12 months
-    different_address:
-      yes: Yes
-      no: No
-    user_research:
-      yes: Yes
-      no: No
   unaccompanied_minor:
     questions:
       privacy_statement:
@@ -402,33 +401,49 @@ en:
       sponsored_children_age:
         short: Sponsored children age
         full: Is the child you want to sponsor under 18?
+        "yes": "Yes"
+        "no": "No"
       sponsored_children_living_december:
         short: Sponsored children living december
         full: Was the child living in Ukraine on or before 31 December 2021?
         hint: Select 'Yes' even if they were temporarily away at the time.
           Select 'No' if they were born after 31 December 2021.
+        "yes": "Yes"
+        "no": "No"
       sponsored_children_december_birth:
         short: Sponsored children december birth
         full: Was the child born after 31 December 2021?
+        "yes": "Yes"
+        "no": "No"
       sponsored_children_legal_guardian_travelling:
         short: Sponsored children legal guardian traveling
         full: Are they travelling to the UK with a parent or legal guardian?
         hint: This excludes travelling with another relative, such as a grandmother, aunt or uncle who is not their legal guardian.
+        "yes": "Yes"
+        "no": "No"
       sponsored_children_legal_guardian_consent:
         short: Sponsored children legal guardian consent
         full: Can you upload both consent forms?
         hint_html: You must be able to upload both completed and signed consent forms from at least one of the child's parents or their legal guardian.<br /><br /><a target="_blank" href="https://www.gov.uk/guidance/homes-for-ukraine-guidance-for-sponsors-children-and-minors-applying-without-parents-or-legal-guardians#parent-or-legal-guardian-consent">Read guidance about which consent forms are required</a>
+        "yes": "Yes"
+        "no": "No"
       sponsor_british_citizenship:
         short: Sponsor british citizenship
         full: Are you a British citizen?
+        "yes": "Yes"
+        "no": "No"
       sponsor_right_to_live_in_uk:
         short: Sponsor right to live in the UK
         full: Do you have permission to live in the UK for the minimum period?
         hint_html: You will need permission to live in the UK for at least <ul><li>3 years</li></ul> OR <ul><li>Until the child turns 18 and you have hosted them for at least 6 months</li></ul>
+        "yes": "Yes"
+        "no": "No"        
       sponsor_commitment:
         short: Sponsor commitment
         full: Can you commit to hosting the child for the minimum period?
         hint_html: You must commit to hosting the child in the UK for at least<ul><li>3 years</li></ul> OR <ul><li>Until the child turns 18 and you have hosted them for at least 6 months</li>
+        "yes": "Yes"
+        "no": "No"
       eligibility_completed:
         short: Eligibility checks completed
       fullname:
@@ -531,6 +546,8 @@ en:
         hint_html: |
           <div class="govuk-inset-text">%{formatted_address}</div>
         hint: There must be at least one an adult living with the child, but it doesn't have to be you. If you select 'No', we will ask you for this adult's details.
+        "yes": "Yes"
+        "no": "No"
       other_adults_address:
         short: Over 16s
         full: Will anyone else over the age of 16 be living at this address?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,7 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  continue: "Continue"
   yes_no_types:
     "yes": "Yes"
     "no": "No"


### PR DESCRIPTION
Turns out we had a problem in `locales/en.yaml` and we completely missed this commented bit

```
# The following keys must be escaped otherwise they will not be retrieved by
# the default I18n backend:
#
# true, false, on, off, yes, no
```

I've now properly scoped the yes/no answers to their respective questions, except for a couple of places where I used the `yes_no_types` as a fallback. A lot of duplicated yes/no I get it, but it's a bit more clear like this I think.