### PR TITLE
[accessibility fixes] DAC_Non-Descriptive_Label_02

### DIFF
--- a/app/views/sponsor-a-child/steps/1.html.erb
+++ b/app/views/sponsor-a-child/steps/1.html.erb
@@ -16,7 +16,7 @@
                                            @application.eligibility_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.different_address")) },
                                            :id,
                                            :name,
-                                           legend: { text: "", hidden: true }
+                                           legend: { text: t('sponsored_children_age.full', scope: "unaccompanied_minor.questions"), hidden: true }
       %>
       </fieldset>
       <%= f.govuk_submit t('continue') %>

--- a/app/views/sponsor-a-child/steps/11.html.erb
+++ b/app/views/sponsor-a-child/steps/11.html.erb
@@ -15,7 +15,7 @@
           %i[true false].map{ |val| OpenStruct.new(id: val, name: val==:true ? "Yes" : "No")},
           :id,
           :name,
-          legend: {hidden:true},
+          legend: { text:t('other_names.full', scope: "unaccompanied_minor.questions"), hidden:true },
           hint: { text: t('other_names.hint', scope: "unaccompanied_minor.questions")}
       %>
       </fieldset>

--- a/app/views/sponsor-a-child/steps/20.html.erb
+++ b/app/views/sponsor-a-child/steps/20.html.erb
@@ -17,7 +17,7 @@
           %i[true false].map{ |val| OpenStruct.new(id: val, name: val==:true ? "Yes" : "No")},
           :id,
           :name,
-          legend: {hidden: true},
+          legend: { text: t('sponsor_has_other_nationality.full', scope: "unaccompanied_minor.questions"), hidden: true },
           hint: { text: t('sponsor_has_other_nationality.hint', scope: "unaccompanied_minor.questions")}
       %>
       </fieldset>

--- a/app/views/sponsor-a-child/steps/25.html.erb
+++ b/app/views/sponsor-a-child/steps/25.html.erb
@@ -36,7 +36,7 @@
           @application.other_adults_address_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.different_address")) },
           :id,
           :name,
-          legend: { text: "", hidden: true }
+          legend: { text: t('other_adults_address.full', scope: "unaccompanied_minor.questions"), hidden: true }
       %>
       </fieldset>
       <div class="govuk-button-group">

--- a/app/views/sponsor-a-child/steps/35.html.erb
+++ b/app/views/sponsor-a-child/steps/35.html.erb
@@ -31,7 +31,7 @@
 
     <%= form_for @application, url: "/sponsor-a-child/steps/35", method: :post do |f| %>
       <%= f.govuk_text_field :have_parental_consent,
-                             label: { text: "No label", hidden: true },
+                             label: { text: 'Continue to form upload', hidden: true },
                              type: "hidden",
                              value: "yes"
       %>

--- a/app/views/sponsor-a-child/steps/6.html.erb
+++ b/app/views/sponsor-a-child/steps/6.html.erb
@@ -26,7 +26,7 @@
                                            @application.eligibility_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.different_address")) },
                                            :id,
                                            :name,
-                                           legend: { text: "", hidden: true }
+                                           legend: { text: t('sponsor_commitment.full', scope: "unaccompanied_minor.questions"), hidden: true }
       %>
       </fieldset>
       <%= f.govuk_submit t('continue') %>

--- a/app/views/sponsor-a-child/steps/7.html.erb
+++ b/app/views/sponsor-a-child/steps/7.html.erb
@@ -26,7 +26,7 @@
                                            @application.eligibility_types.map{ |type| OpenStruct.new(id: type, name: t(type, scope: "unaccompanied_minor.different_address")) },
                                            :id,
                                            :name,
-                                           legend: { text: "", hidden: true }
+                                           legend: { text: t('sponsor_right_to_live_in_uk.full', scope: "unaccompanied_minor.questions"), hidden: true }
       %>
       </fieldset>
       <%= f.govuk_submit t('continue') %>


### PR DESCRIPTION
We cannot get rid of the label using govuk's formbuilder, and the default for a label is `name_of_field` so I have modified the suggested solution to ensure there is a hidden text that states what the continue button is for

This also fixes https://digital.dclg.gov.uk/jira/browse/UKRSS-1832 due to a commit mistake on my end