### PR TITLE
Clamav consent form scanning

### DIFF
--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -64,7 +64,7 @@ jobs:
           --health-retries 5
       clamav:
         # Docker Hub image
-        image: clamav/clamav
+        image: clamav/clamav:stable
         ports:
           - 3310:3310
 

--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -62,6 +62,11 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      clamav:
+        # Docker Hub image
+        image: clamav/clamav
+        ports:
+          - 3310:3310
 
     env:
       RAILS_ENV: test
@@ -89,6 +94,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+
+      - name: Install clamav
+        run: |
+          sudo apt-get update
+          sudo apt-get install clamdscan
 
       - name: Create DB
         run: |

--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -101,12 +101,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install clamdscan
-      - name: Create clamav config file
-        run: |
-          sudo touch /etc/clamav/clamd.conf
-          sudo chown "$(whoami):$(whoami)" /etc/clamav/clamd.conf
-          echo "TCPAddr $CLAMD_HOST" > /etc/clamav/clamd.conf
-          echo "TCPSocket $CLAMD_PORT" >> /etc/clamav/clamd.conf
 
       - name: Create DB
         run: |

--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -78,6 +78,8 @@ jobs:
       DB_USERNAME: ukraine
       DB_PASSWORD: password
       GOVUK_NOTIFY_API_KEY: ${{ secrets.GOVUK_NOTIFY_API_KEY }}
+      CLAMD_HOST: localhost
+      CLAMD_PORT: 3310
 
     steps:
       - name: Checkout
@@ -99,6 +101,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install clamdscan
+      - name: Create clamav config file
+        run: |
+          sudo touch /etc/clamav/clamd.conf
+          sudo chown "$(whoami):$(whoami)" /etc/clamav/clamd.conf
+          echo "TCPAddr $CLAMD_HOST" > /etc/clamav/clamd.conf
+          echo "TCPSocket $CLAMD_PORT" >> /etc/clamav/clamd.conf
 
       - name: Create DB
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ data/startup_info.json
 # Ignore Rails asset folder
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+# Ignore generated clamd config files for testing
+config/clamd.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,11 @@ RUN gem install bundler --no-document && \
   bundle install && \
   yarn install
 
+RUN apk add --no-cache clamav-clamdscan
+RUN mkdir /etc/clamav
+RUN echo "TCPSocket 3310" > /etc/clamav/clamd.conf
+RUN echo "TCPAddr localhost" >> /etc/clamav/clamd.conf
+
 COPY . /app
 
 RUN RAILS_ENV=${RAILS_ENV} INSTANCE_NAME=${INSTANCE_NAME} bundle exec rails assets:precompile

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,6 @@ RUN gem install bundler --no-document && \
 
 RUN apk add --no-cache clamav-clamdscan
 RUN mkdir /etc/clamav
-RUN echo "TCPSocket 3310" > /etc/clamav/clamd.conf
-RUN echo "TCPAddr localhost" >> /etc/clamav/clamd.conf
 
 COPY . /app
 

--- a/Gemfile
+++ b/Gemfile
@@ -36,8 +36,8 @@ gem "sentry-ruby"
 
 # S3 & Anti-virus
 gem "aws-sdk-s3"
-gem "ratonvirus"
 gem "clamby"
+gem "ratonvirus"
 gem "ratonvirus-clamby"
 
 # Postcode parsing

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem "sentry-ruby"
 # S3 & Anti-virus
 gem "aws-sdk-s3"
 gem "ratonvirus"
+gem "clamby"
+gem "ratonvirus-clamby"
 
 # Postcode parsing
 gem "uk_postcode"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    clamby (1.6.11)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
@@ -294,6 +295,9 @@ GEM
     rake (13.2.1)
     ratonvirus (0.4.3)
       activesupport (~> 7.0)
+    ratonvirus-clamby (0.4.0)
+      clamby (~> 1.6)
+      ratonvirus (~> 0.4.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
@@ -441,6 +445,7 @@ DEPENDENCIES
   bundler-audit
   byebug
   capybara
+  clamby
   cssbundling-rails
   csv (~> 3.3)
   dotenv-rails
@@ -459,6 +464,7 @@ DEPENDENCIES
   rails (~> 7.2.2)
   rails-controller-testing
   ratonvirus
+  ratonvirus-clamby
   redis
   rspec-rails
   rubocop-govuk

--- a/config/initializers/clamby.rb
+++ b/config/initializers/clamby.rb
@@ -1,5 +1,16 @@
+host = ENV.fetch("CLAMD_HOST", "localhost")
+port = ENV.fetch("CLAMD_PORT", "3310")
+config_path = Rails.env.development? || Rails.env.test? ? "config/clamd.conf" : "/etc/clamav/clamd.conf"
+
+config = %{
+TCPAddr #{host}
+TCPSocket #{port}
+}
+
+File.write(config_path, config)
+
 Clamby.configure({
   daemonize: true,
   stream: true,
-  error_file: "/etc/clamav/clamd.conf"
+  error_file: config_path
 })

--- a/config/initializers/clamby.rb
+++ b/config/initializers/clamby.rb
@@ -2,15 +2,15 @@ host = ENV.fetch("CLAMD_HOST", "localhost")
 port = ENV.fetch("CLAMD_PORT", "3310")
 config_path = ENV.fetch("CLAMD_CONFIG_PATH", "config/clamd.conf")
 
-config = %{
+config = %(
 TCPAddr #{host}
 TCPSocket #{port}
-}
+)
 
 File.write(config_path, config)
 
 Clamby.configure({
   daemonize: true,
   stream: true,
-  error_file: config_path
+  config_file: config_path,
 })

--- a/config/initializers/clamby.rb
+++ b/config/initializers/clamby.rb
@@ -1,6 +1,6 @@
 host = ENV.fetch("CLAMD_HOST", "localhost")
 port = ENV.fetch("CLAMD_PORT", "3310")
-config_path = Rails.env.development? || Rails.env.test? ? "config/clamd.conf" : "/etc/clamav/clamd.conf"
+config_path = ENV.fetch("CLAMD_CONFIG_PATH", "config/clamd.conf")
 
 config = %{
 TCPAddr #{host}

--- a/config/initializers/clamby.rb
+++ b/config/initializers/clamby.rb
@@ -5,6 +5,9 @@ config_path = ENV.fetch("CLAMD_CONFIG_PATH", "config/clamd.conf")
 config = %(
 TCPAddr #{host}
 TCPSocket #{port}
+StreamMinPort 1024
+StreamMaxPort 2048
+StreamMaxLength 20M
 )
 
 File.write(config_path, config)

--- a/config/initializers/clamby.rb
+++ b/config/initializers/clamby.rb
@@ -1,0 +1,5 @@
+Clamby.configure({
+  daemonize: true,
+  stream: true,
+  error_file: "/etc/clamav/clamd.conf"
+})

--- a/config/initializers/ratonvirus.rb
+++ b/config/initializers/ratonvirus.rb
@@ -1,5 +1,5 @@
 # config/initializers/ratonvirus.rb
 Ratonvirus.configure do |config|
-  config.scanner = :eicar
+  config.scanner = :clamby
   config.storage = :filepath
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,3 +58,9 @@ services:
     build: http-mock-server
     ports:
       - "8081:8081"
+
+  clamav:
+    image: clamav/clamav-debian:stable
+    restart: always
+    ports:
+      - "3310:3310"


### PR DESCRIPTION
This PR configures ratonvirus to scan uploaded consent forms with ClamAV via clamby, rather than with just scanning for the EICAR test file.

It is to be deployed after deploying https://github.com/communitiesuk/ukraine-sponsor-terraform-scripts/pull/148, which creates the container in AWS