### PR TITLE
Make "audit dependencies" step optional for deploying to AWS

### DIFF
--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     environment: aws-staging
-    needs: [lint, test, audit, brakeman-scan]
+    needs: [lint, test, brakeman-scan]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This is preventing us from deploying updates while other updates are outstanding