### PR TITLE
Reduce maximum consent form file size from 20MB -> 8MB

### DIFF
--- a/app/models/concerns/uam_validations.rb
+++ b/app/models/concerns/uam_validations.rb
@@ -206,7 +206,7 @@ module UamValidations
   end
 
   def validate_uk_parent_consent_file_size
-    if !@uk_parental_consent_file_size.nil? && @uk_parental_consent_file_size > 1024 * 1024 * 20
+    if !@uk_parental_consent_file_size.nil? && @uk_parental_consent_file_size > 1024 * 1024 * 8
       errors.add(:uk_parental_consent, I18n.t(:file_too_large, scope: :error))
     end
   end
@@ -230,7 +230,7 @@ module UamValidations
   end
 
   def validate_ukraine_parent_consent_file_size
-    if !@ukraine_parental_consent_file_size.nil? && @ukraine_parental_consent_file_size > 1024 * 1024 * 20
+    if !@ukraine_parental_consent_file_size.nil? && @ukraine_parental_consent_file_size > 1024 * 1024 * 8
       errors.add(:ukraine_parental_consent, I18n.t(:file_too_large, scope: :error))
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -654,7 +654,7 @@ en:
     number_adults_residential: There must be at least 1 adult living at your residential address
     invalid_file_type_chosen: You can only upload pdf, jpeg or png files
     no_file_chosen: You must choose a file
-    file_too_large: Your file must be smaller than 20MB
+    file_too_large: Your file must be smaller than 8MB
     file_malicious: The uploaded file has been detected as malicious. Please upload a different file
     invalid_date_of_birth: Enter a valid date of birth
     date_of_birth_future: This date cannot be in the future. Enter a valid date of birth.

--- a/spec/models/unaccompanied_minor_spec.rb
+++ b/spec/models/unaccompanied_minor_spec.rb
@@ -232,24 +232,24 @@ RSpec.describe UnaccompaniedMinor, type: :model do
       expect(app.valid?).to be(true)
     end
 
-    it "ensure the file is 20MB or smaller" do
+    it "ensure the file is 8MB or smaller" do
       app = described_class.new
       app.partial_validation = %i[uk_parental_consent_file_size]
 
-      app.uk_parental_consent_file_size = 1024 * 1024 * 21
+      app.uk_parental_consent_file_size = 1024 * 1024 * 9
       expect(app.valid?).to be(false)
-      expect(app.errors[:uk_parental_consent]).to include("Your file must be smaller than 20MB")
+      expect(app.errors[:uk_parental_consent]).to include("Your file must be smaller than 8MB")
 
-      app.uk_parental_consent_file_size = 1024 * 1024 * 20
+      app.uk_parental_consent_file_size = 1024 * 1024 * 8
       expect(app.valid?).to be(true)
 
       app.partial_validation = %i[ukraine_parental_consent_file_size]
 
-      app.ukraine_parental_consent_file_size = 1024 * 1024 * 21
+      app.ukraine_parental_consent_file_size = 1024 * 1024 * 9
       expect(app.valid?).to be(false)
-      expect(app.errors[:ukraine_parental_consent]).to include("Your file must be smaller than 20MB")
+      expect(app.errors[:ukraine_parental_consent]).to include("Your file must be smaller than 8MB")
 
-      app.ukraine_parental_consent_file_size = 1024 * 1024 * 20
+      app.ukraine_parental_consent_file_size = 1024 * 1024 * 8
       expect(app.valid?).to be(true)
     end
 

--- a/spec/system/unaccompanied_minor_file_upload_spec.rb
+++ b/spec/system/unaccompanied_minor_file_upload_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Unaccompanied minor expression of interest", type: :system do
       attach_file("unaccompanied-minor-uk-parental-consent-field", test_file_path)
       click_button("Continue")
 
-      expect(page).to have_content("Your file must be smaller than 20MB")
+      expect(page).to have_content("Your file must be smaller than 8MB")
     end
 
     it "gets rejected trying to upload a file that's too large Ukraine" do
@@ -65,7 +65,7 @@ RSpec.describe "Unaccompanied minor expression of interest", type: :system do
       attach_file("unaccompanied-minor-ukraine-parental-consent-field", test_file_path)
       click_button("Continue")
 
-      expect(page).to have_content("Your file must be smaller than 20MB")
+      expect(page).to have_content("Your file must be smaller than 8MB")
     end
 
     it "gets rejected trying to upload a malicious UK consent form" do


### PR DESCRIPTION
The Share API cannot handle HTTP requests larger than 10MB due to an AWS API Gateway limitation