### PR TITLE
Bump rack from 3.1.20 to 3.1.21 and lodash from 4.17.23 to 4.18.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,7 +258,7 @@ GEM
     puma (6.5.0)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.1.20)
+    rack (3.1.21)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
     rack-session (2.1.1)

--- a/automated_tests/package-lock.json
+++ b/automated_tests/package-lock.json
@@ -1769,10 +1769,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "node_modules/lodash.isempty": {
       "version": "4.4.0",
@@ -4179,9 +4178,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash.isempty": {
       "version": "4.4.0",


### PR DESCRIPTION
Manually bumps the bundler group with 1 update in the / directory: [rack](https://github.com/rack/rack) on behalf of Dependabot (see https://github.com/communitiesuk/ukraine-sponsor-resettlement/pull/662)

Bumps the npm_and_yarn group with 1 update in the /automated_tests directory: [lodash](https://github.com/lodash/lodash) on behalf of Dependabot (see https://github.com/communitiesuk/ukraine-sponsor-resettlement/pull/663)

Updates `rack` from 3.1.20 to 3.1.21
- [Release notes](https://github.com/rack/rack/releases)
- [Changelog](https://github.com/rack/rack/blob/main/CHANGELOG.md)
- [Commits](https://github.com/rack/rack/compare/v3.1.20...v3.1.21)

Updates `lodash` from 4.17.23 to 4.18.1
- [Release notes](https://github.com/lodash/lodash/releases)
- [Commits](https://github.com/lodash/lodash/compare/4.17.23...4.18.1)

---
updated-dependencies:
- dependency-name: rack dependency-version: 3.1.21 dependency-type: indirect dependency-group: bundler ...
- dependency-name: lodash
  dependency-version: 4.18.1
  dependency-type: indirect
  dependency-group: npm_and_yarn
...