### PR TITLE
Add local dev URL hint on Puma boot

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -32,3 +32,9 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
+
+# Local dev URL on boot
+on_booted do
+  port = ENV.fetch("PORT") { 3000 }
+  puts "\n=> Local dev: http://localhost:#{port}/expression-of-interest/self-assessment/property-suitable\n\n"
+end


### PR DESCRIPTION
Prints a clickable URL to the correct entry point on startup, since the root path redirects to GOV.UK.